### PR TITLE
Implement serde for rpds types (optional dependency)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde = { version = "1", optional = true }
 # TODO This will probably be part of rust in the future (see https://github.com/rust-lang/rust/issues/29553)
 bencher = "0.1"
 rand = "0.3"
+# needed to test serde
+bincode = "0.9"
 
 [features]
 fatal-warnings = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ include = [
 travis-ci = { repository = "orium/rpds", branch = "master" }
 codecov = { repository = "orium/rpds", branch = "master", service = "github" }
 
+[dependencies]
+serde = { version = "1", optional = true }
+
 [dev-dependencies]
 # TODO This will probably be part of rust in the future (see https://github.com/rust-lang/rust/issues/29553)
 bencher = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,10 @@
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(test)]
+#[cfg(feature = "serde")]
+extern crate bincode;
+
 mod utils;
 
 pub mod sequence;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,9 @@
 //! assert_eq!(set_positive.first(), Some(&"one"));
 //! ```
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 mod utils;
 
 pub mod sequence;

--- a/src/map/hash_trie_map/test.rs
+++ b/src/map/hash_trie_map/test.rs
@@ -962,3 +962,13 @@ fn test_clone() -> () {
     assert_eq!(clone.get("hello"), Some(&4));
     assert_eq!(clone.get("there"), Some(&5));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let hashtriemap: HashTrieMap<i32, i32> = HashTrieMap::from_iter(vec![(5,6),(7,8),(9,10),(11,12)].into_iter());
+    let encoded = serialize(&hashtriemap, Bounded(100)).unwrap();
+    let decoded: HashTrieMap<i32, i32> = deserialize(&encoded).unwrap();
+    assert_eq!(hashtriemap, decoded);
+}

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1062,3 +1062,13 @@ fn test_clone() -> () {
     assert_eq!(clone.get("hello"), Some(&4));
     assert_eq!(clone.get("there"), Some(&5));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let rbtreemap: RedBlackTreeMap<i32, i32> = RedBlackTreeMap::from_iter(vec![(5,6),(7,8),(9,10),(11,12)].into_iter());
+    let encoded = serialize(&rbtreemap, Bounded(100)).unwrap();
+    let decoded: RedBlackTreeMap<i32, i32> = deserialize(&encoded).unwrap();
+    assert_eq!(rbtreemap, decoded);
+}

--- a/src/queue/test.rs
+++ b/src/queue/test.rs
@@ -368,3 +368,13 @@ fn test_clone() -> () {
     assert!(clone.iter().eq(queue.iter()));
     assert_eq!(clone.len(), queue.len());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let queue: Queue<i32> = Queue::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&queue, Bounded(100)).unwrap();
+    let decoded: Queue<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(queue, decoded);
+}

--- a/src/sequence/list/mod.rs
+++ b/src/sequence/list/mod.rs
@@ -10,6 +10,15 @@ use std::hash::{Hasher, Hash};
 use std::borrow::Borrow;
 use std::iter::FromIterator;
 
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, Serializer, SerializeSeq};
+#[cfg(feature = "serde")]
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde")]
+use std::marker::PhantomData;
+#[cfg(feature = "serde")]
+use std::fmt;
+
 // TODO Use impl trait instead of this when available.
 pub type Iter<'a, T> = ::std::iter::Map<IterArc<'a, T>, fn(&Arc<T>) -> &T>;
 
@@ -266,6 +275,64 @@ impl<'a, T> Iterator for IterArc<'a, T> {
 }
 
 impl<'a, T> ExactSizeIterator for IterArc<'a, T> {}
+
+#[cfg(feature = "serde")]
+impl<T> Serialize for List<T> where T: Serialize {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_seq(Some(self.len()))?;
+        for item in self {
+            state.serialize_element(&item)?;
+        }
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Deserialize<'de> for List<T> where T: Deserialize<'de> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(ListVisitor{phantom: PhantomData})
+    }
+}
+
+#[cfg(feature = "serde")]
+struct ListVisitor<T> {
+    phantom: PhantomData<T>
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> Visitor<'de> for ListVisitor<T>
+where T: Deserialize<'de>,
+{
+    type Value = List<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+    {
+        let mut vec: Vec<T> = if let Some(capacity) = seq.size_hint() {
+                Vec::with_capacity(capacity)
+            } else {
+                Vec::new()
+            };
+
+        while let Some(value) = seq.next_element()? {
+            vec.push(value);
+        }
+
+        let mut list: List<T> = List::new();
+
+        for value in vec.into_iter().rev() {
+            list = list.push_front(value);
+        }
+
+        Ok(list)
+    }
+}
+
 
 #[cfg(test)]
 mod test;

--- a/src/sequence/list/test.rs
+++ b/src/sequence/list/test.rs
@@ -289,3 +289,13 @@ fn test_clone() -> () {
     assert_eq!(clone.len(), list.len());
     assert_eq!(clone.last(), list.last());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let list: List<i32> = List::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&list, Bounded(100)).unwrap();
+    let decoded: List<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(list, decoded);
+}

--- a/src/sequence/vector/test.rs
+++ b/src/sequence/vector/test.rs
@@ -684,3 +684,13 @@ fn test_clone() -> () {
     assert_eq!(clone.len(), vector.len());
     assert!(clone.iter().eq(vector.iter()));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let vector: Vector<i32> = Vector::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&vector, Bounded(100)).unwrap();
+    let decoded: Vector<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(vector, decoded);
+}

--- a/src/set/hash_trie_set/test.rs
+++ b/src/set/hash_trie_set/test.rs
@@ -234,3 +234,13 @@ fn test_clone() -> () {
     assert!(clone.contains("hello"));
     assert!(clone.contains("there"));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let hashtrieset: HashTrieSet<i32> = HashTrieSet::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&hashtrieset, Bounded(100)).unwrap();
+    let decoded: HashTrieSet<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(hashtrieset, decoded);
+}

--- a/src/set/red_black_tree_set/test.rs
+++ b/src/set/red_black_tree_set/test.rs
@@ -254,3 +254,13 @@ fn test_clone() -> () {
     assert!(clone.contains("hello"));
     assert!(clone.contains("there"));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let rbtreeset: RedBlackTreeSet<i32> = RedBlackTreeSet::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&rbtreeset, Bounded(100)).unwrap();
+    let decoded: RedBlackTreeSet<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(rbtreeset, decoded);
+}

--- a/src/stack/test.rs
+++ b/src/stack/test.rs
@@ -243,3 +243,13 @@ fn test_clone() -> () {
     assert!(clone.iter().eq(stack.iter()));
     assert_eq!(clone.size(), stack.size());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() {
+    use bincode::{serialize, deserialize, Bounded};
+    let stack: Stack<i32> = Stack::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&stack, Bounded(100)).unwrap();
+    let decoded: Stack<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(stack, decoded);
+}


### PR DESCRIPTION
This patch set adds serde as an optional dependency; serialization/deserialization code isn't compiled if it's not used. Addresses issue #1 

You can run tests that include serialization/deserialization code using

    cargo test --features serde

or more likely if you want the tests to finish somewhat promptly,

    cargo test --release --features serde
