### PR TITLE
Implement serde for rpds types, pull request #4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ addons:
       - jq
 
 script:
-  - cargo build --features fatal-warnings
-  - cargo test  --features fatal-warnings
-  - cargo bench --features fatal-warnings
-  - cargo doc   --features fatal-warnings
+  - cargo build --features fatal-warnings,serde
+  - cargo test  --features fatal-warnings,serde
+  - cargo bench --features fatal-warnings,serde
+  - cargo doc   --features fatal-warnings,serde
   - cargo package
 
 # TODO Do not build kcov when v34 is available, just install it directly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde = { version = "1", optional = true }
 # TODO This will probably be part of rust in the future (see https://github.com/rust-lang/rust/issues/29553)
 bencher = "0.1"
 rand = "0.3"
+# needed to test serde
+bincode = "0.9"
 
 [features]
 fatal-warnings = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ include = [
 travis-ci = { repository = "orium/rpds", branch = "master" }
 codecov = { repository = "orium/rpds", branch = "master", service = "github" }
 
+[dependencies]
+serde = { version = "1", optional = true }
+
 [dev-dependencies]
 # TODO This will probably be part of rust in the future (see https://github.com/rust-lang/rust/issues/29553)
 bencher = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,10 @@
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(test)]
+#[cfg(feature = "serde")]
+extern crate bincode;
+
 mod utils;
 
 pub mod sequence;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,9 @@
 //! assert_eq!(set_positive.first(), Some(&"one"));
 //! ```
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 mod utils;
 
 pub mod sequence;

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -856,5 +856,58 @@ impl<'a, K, V> Iterator for Iter<'a, K, V>
 
 impl<'a, K: Eq + Hash, V> ExactSizeIterator for Iter<'a, K, V> {}
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+    use std::marker::PhantomData;
+    use std::fmt;
+
+    impl<K, V, H> Serialize for HashTrieMap<K, V, H>
+        where K: Eq + Hash + Serialize,
+              V: Serialize,
+              H: BuildHasher + Clone + Default {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_map(self)
+        }
+    }
+
+    impl<'de, K, V, H> Deserialize<'de> for HashTrieMap<K, V, H>
+        where K: Eq + Hash + Deserialize<'de>,
+              V: Deserialize<'de>,
+              H: BuildHasher + Clone + Default {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<HashTrieMap<K, V, H>, D::Error> {
+            deserializer.deserialize_map(HashTrieMapVisitor { phantom: PhantomData } )
+        }
+    }
+
+    struct HashTrieMapVisitor<K, V, H> {
+        phantom: PhantomData<(K, V, H)>
+    }
+
+    impl<'de, K, V, H> Visitor<'de> for HashTrieMapVisitor<K, V, H>
+        where K: Eq + Hash + Deserialize<'de>,
+              V: Deserialize<'de>,
+              H: BuildHasher + Clone + Default {
+        type Value = HashTrieMap<K, V, H>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<HashTrieMap<K, V, H>, A::Error>
+            where A: MapAccess<'de> {
+            let mut hashtriemap = HashTrieMap::new_with_hasher(Default::default());
+
+            while let Some((k, v)) = map.next_entry()? {
+                hashtriemap = hashtriemap.insert(k, v);
+            }
+
+            Ok(hashtriemap)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/map/hash_trie_map/test.rs
+++ b/src/map/hash_trie_map/test.rs
@@ -962,3 +962,13 @@ fn test_clone() -> () {
     assert_eq!(clone.get("hello"), Some(&4));
     assert_eq!(clone.get("there"), Some(&5));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let hashtriemap: HashTrieMap<i32, i32> = HashTrieMap::from_iter(vec![(5,6),(7,8),(9,10),(11,12)].into_iter());
+    let encoded = serialize(&hashtriemap, Bounded(100)).unwrap();
+    let decoded: HashTrieMap<i32, i32> = deserialize(&encoded).unwrap();
+    assert_eq!(hashtriemap, decoded);
+}

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1182,5 +1182,55 @@ impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
 
 impl<'a, K: Ord, V> ExactSizeIterator for Iter<'a, K, V> {}
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+    use std::marker::PhantomData;
+    use std::fmt;
+
+    impl<K, V> Serialize for RedBlackTreeMap<K, V>
+        where K: Ord + Serialize,
+              V: Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_map(self)
+        }
+    }
+
+    impl<'de, K, V> Deserialize<'de> for RedBlackTreeMap<K, V>
+        where K: Ord + Deserialize<'de>,
+              V: Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<RedBlackTreeMap<K, V>, D::Error> {
+            deserializer.deserialize_map(RedBlackTreeMapVisitor { phantom: PhantomData } )
+        }
+    }
+
+    struct RedBlackTreeMapVisitor<K, V> {
+        phantom: PhantomData<(K, V)>
+    }
+
+    impl<'de, K, V> Visitor<'de> for RedBlackTreeMapVisitor<K, V>
+        where K: Ord + Deserialize<'de>,
+              V: Deserialize<'de> {
+        type Value = RedBlackTreeMap<K, V>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<RedBlackTreeMap<K, V>, A::Error>
+            where A: MapAccess<'de> {
+            let mut rbtreemap = RedBlackTreeMap::new();
+
+            while let Some((k, v)) = map.next_entry()? {
+                rbtreemap = rbtreemap.insert(k, v);
+            }
+
+            Ok(rbtreemap)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1062,3 +1062,13 @@ fn test_clone() -> () {
     assert_eq!(clone.get("hello"), Some(&4));
     assert_eq!(clone.get("there"), Some(&5));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let rbtreemap: RedBlackTreeMap<i32, i32> = RedBlackTreeMap::from_iter(vec![(5,6),(7,8),(9,10),(11,12)].into_iter());
+    let encoded = serialize(&rbtreemap, Bounded(100)).unwrap();
+    let decoded: RedBlackTreeMap<i32, i32> = deserialize(&encoded).unwrap();
+    assert_eq!(rbtreemap, decoded);
+}

--- a/src/queue/mod.rs
+++ b/src/queue/mod.rs
@@ -248,5 +248,30 @@ impl<'a, T> Iterator for LazilyReversedListIter<'a, T> {
 
 impl<'a, T> ExactSizeIterator for LazilyReversedListIter<'a, T> {}
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer};
+
+    impl<T> Serialize for Queue<T>
+        where T: Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_seq(self)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for Queue<T>
+        where T: Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Queue<T>, D::Error> {
+            let list: List<T> = Deserialize::deserialize(deserializer)?;
+            Ok(Queue {
+                out_list: list,
+                in_list:  List::new(),
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/queue/test.rs
+++ b/src/queue/test.rs
@@ -368,3 +368,13 @@ fn test_clone() -> () {
     assert!(clone.iter().eq(queue.iter()));
     assert_eq!(clone.len(), queue.len());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let queue: Queue<i32> = Queue::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&queue, Bounded(100)).unwrap();
+    let decoded: Queue<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(queue, decoded);
+}

--- a/src/sequence/list/mod.rs
+++ b/src/sequence/list/mod.rs
@@ -267,5 +267,61 @@ impl<'a, T> Iterator for IterArc<'a, T> {
 
 impl<'a, T> ExactSizeIterator for IterArc<'a, T> {}
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+    use std::marker::PhantomData;
+    use std::fmt;
+
+    impl<T> Serialize for List<T>
+        where T: Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_seq(self)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for List<T> where T: Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<List<T>, D::Error> {
+            deserializer.deserialize_seq(ListVisitor { phantom: PhantomData } )
+        }
+    }
+
+    struct ListVisitor<T> {
+        phantom: PhantomData<T>
+    }
+
+    impl<'de, T> Visitor<'de> for ListVisitor<T>
+        where T: Deserialize<'de> {
+        type Value = List<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<List<T>, A::Error>
+            where A: SeqAccess<'de> {
+            let mut vec: Vec<T> = if let Some(capacity) = seq.size_hint() {
+                    Vec::with_capacity(capacity)
+                } else {
+                    Vec::new()
+                };
+
+            while let Some(value) = seq.next_element()? {
+                vec.push(value);
+            }
+
+            let mut list: List<T> = List::new();
+
+            for value in vec.into_iter().rev() {
+                list = list.push_front(value);
+            }
+
+            Ok(list)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/sequence/list/test.rs
+++ b/src/sequence/list/test.rs
@@ -289,3 +289,13 @@ fn test_clone() -> () {
     assert_eq!(clone.len(), list.len());
     assert_eq!(clone.last(), list.last());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let list: List<i32> = List::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&list, Bounded(100)).unwrap();
+    let decoded: List<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(list, decoded);
+}

--- a/src/sequence/vector/mod.rs
+++ b/src/sequence/vector/mod.rs
@@ -679,5 +679,52 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+    use std::marker::PhantomData;
+    use std::fmt;
+
+    impl<T> Serialize for Vector<T>
+        where T: Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_seq(self)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for Vector<T>
+        where T: Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Vector<T>, D::Error> {
+            deserializer.deserialize_seq(VectorVisitor { phantom: PhantomData } )
+        }
+    }
+
+    struct VectorVisitor<T> {
+        phantom: PhantomData<T>
+    }
+
+    impl<'de, T> Visitor<'de> for VectorVisitor<T>
+        where T: Deserialize<'de> {
+        type Value = Vector<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Vector<T>, A::Error>
+            where A: SeqAccess<'de> {
+            let mut vector = Vector::new();
+
+            while let Some(value) = seq.next_element()? {
+                vector = vector.push_back(value);
+            }
+
+            Ok(vector)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/sequence/vector/test.rs
+++ b/src/sequence/vector/test.rs
@@ -684,3 +684,13 @@ fn test_clone() -> () {
     assert_eq!(clone.len(), vector.len());
     assert!(clone.iter().eq(vector.iter()));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let vector: Vector<i32> = Vector::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&vector, Bounded(100)).unwrap();
+    let decoded: Vector<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(vector, decoded);
+}

--- a/src/set/hash_trie_set/test.rs
+++ b/src/set/hash_trie_set/test.rs
@@ -234,3 +234,13 @@ fn test_clone() -> () {
     assert!(clone.contains("hello"));
     assert!(clone.contains("there"));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let hashtrieset: HashTrieSet<i32> = HashTrieSet::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&hashtrieset, Bounded(100)).unwrap();
+    let decoded: HashTrieSet<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(hashtrieset, decoded);
+}

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -164,5 +164,52 @@ impl<T> FromIterator<T> for RedBlackTreeSet<T> where
     }
 }
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+    use std::marker::PhantomData;
+    use std::fmt;
+
+    impl<T> Serialize for RedBlackTreeSet<T>
+        where T: Ord + Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_seq(self)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for RedBlackTreeSet<T>
+        where T: Ord + Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<RedBlackTreeSet<T>, D::Error> {
+            deserializer.deserialize_seq(RedBlackTreeSetVisitor { phantom: PhantomData } )
+        }
+    }
+
+    struct RedBlackTreeSetVisitor<T> {
+        phantom: PhantomData<T>
+    }
+
+    impl<'de, T> Visitor<'de> for RedBlackTreeSetVisitor<T>
+        where T: Ord + Deserialize<'de> {
+        type Value = RedBlackTreeSet<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<RedBlackTreeSet<T>, A::Error>
+            where A: SeqAccess<'de> {
+            let mut rbtreeset = RedBlackTreeSet::new();
+
+            while let Some(value) = seq.next_element()? {
+                rbtreeset = rbtreeset.insert(value);
+            }
+
+            Ok(rbtreeset)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/set/red_black_tree_set/test.rs
+++ b/src/set/red_black_tree_set/test.rs
@@ -254,3 +254,13 @@ fn test_clone() -> () {
     assert!(clone.contains("hello"));
     assert!(clone.contains("there"));
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let rbtreeset: RedBlackTreeSet<i32> = RedBlackTreeSet::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&rbtreeset, Bounded(100)).unwrap();
+    let decoded: RedBlackTreeSet<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(rbtreeset, decoded);
+}

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -153,5 +153,29 @@ impl<T> FromIterator<T> for Stack<T> {
     }
 }
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    use super::*;
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{Deserialize, Deserializer};
+
+    impl<T> Serialize for Stack<T>
+        where T: Serialize {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.collect_seq(self)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for Stack<T>
+        where T: Deserialize<'de> {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Stack<T>, D::Error> {
+            let list: List<T> = Deserialize::deserialize(deserializer)?;
+            Ok(Stack {
+                list: list,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/src/stack/test.rs
+++ b/src/stack/test.rs
@@ -243,3 +243,13 @@ fn test_clone() -> () {
     assert!(clone.iter().eq(stack.iter()));
     assert_eq!(clone.size(), stack.size());
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde() -> () {
+    use bincode::{serialize, deserialize, Bounded};
+    let stack: Stack<i32> = Stack::from_iter(vec![5,6,7,8].into_iter());
+    let encoded = serialize(&stack, Bounded(100)).unwrap();
+    let decoded: Stack<i32> = deserialize(&encoded).unwrap();
+    assert_eq!(stack, decoded);
+}

--- a/tools/codecov.sh
+++ b/tools/codecov.sh
@@ -10,7 +10,7 @@ cd $(dirname "$0")
 cd "$(git rev-parse --show-toplevel)"
 
 # TODO Maybe in the future there will be a better way.  See https://github.com/rust-lang/cargo/issues/1924.
-build=$(cargo test --no-run --message-format=json 2>/dev/null | \
+build=$(cargo test --no-run --message-format=json --features=serde 2>/dev/null | \
     jq -r "select(.profile.test == true) | .filenames[]" | \
     rev | cut -d'/' -f 1 | rev)
 


### PR DESCRIPTION
This patch set adds serde as an optional dependency; serialization/deserialization code isn't compiled if it's not used. Addresses issue #1. Improved version of pull request #2 / #3.

You can run tests that include serialization/deserialization code using

    cargo test --features serde

or more likely if you want the tests to finish somewhat promptly,

    cargo test --release --features serde
  