### PR TITLE
Reuse Arc allocation if the ref count is one

### DIFF
--- a/benches/rpds_vector.rs
+++ b/benches/rpds_vector.rs
@@ -30,6 +30,20 @@ fn vector_push_back(bench: &mut Bencher) -> () {
     });
 }
 
+fn vector_push_back_mut(bench: &mut Bencher) -> () {
+    let limit = iterations(100_000);
+
+    bench.iter_no_drop(|| {
+        let mut vector: Vector<usize> = Vector::new();
+
+        for i in 0..limit {
+            vector.push_back_mut(i);
+        }
+
+        vector
+    });
+}
+
 fn vector_drop_last(bench: &mut Bencher) -> () {
     let limit = iterations(100_000);
     let mut full_vector: Vector<usize> = Vector::new();
@@ -43,6 +57,25 @@ fn vector_drop_last(bench: &mut Bencher) -> () {
 
         for _ in 0..limit {
             vector = vector.drop_last().unwrap();
+        }
+
+        vector
+    });
+}
+
+fn vector_drop_last_mut(bench: &mut Bencher) -> () {
+    let limit = iterations(100_000);
+    let mut full_vector: Vector<usize> = Vector::new();
+
+    for i in 0..limit {
+        full_vector.push_back_mut(i);
+    }
+
+    bench.iter_no_drop(|| {
+        let mut vector: Vector<usize> = full_vector.clone();
+
+        for _ in 0..limit {
+            vector.drop_last_mut().unwrap();
         }
 
         vector
@@ -82,7 +115,9 @@ fn vector_iterate(bench: &mut Bencher) -> () {
 benchmark_group!(
     benches,
     vector_push_back,
+    vector_push_back_mut,
     vector_drop_last,
+    vector_drop_last_mut,
     vector_get,
     vector_iterate
 );

--- a/src/sequence/vector/test.rs
+++ b/src/sequence/vector/test.rs
@@ -36,10 +36,10 @@ mod node {
 
     #[test]
     fn test_drop_last_single_level() -> () {
-        let empty_leaf: Node<u32> = Node::new_empty_leaf();
-        let empty_branch: Node<u32> = Node::new_empty_branch();
-        let singleton_node: Node<u32> = Vector::new().push_back(0).root.as_ref().clone();
-        let one_level_node: Node<u32> = Vector::new()
+        let mut empty_leaf: Node<u32> = Node::new_empty_leaf();
+        let mut empty_branch: Node<u32> = Node::new_empty_branch();
+        let mut singleton_node: Node<u32> = Vector::new().push_back(0).root.as_ref().clone();
+        let mut one_level_node: Node<u32> = Vector::new()
             .push_back(0)
             .push_back(1)
             .root
@@ -49,19 +49,20 @@ mod node {
         assert!(empty_leaf.drop_last().is_none());
         assert!(empty_branch.drop_last().is_none());
         assert!(singleton_node.drop_last().is_none());
-        assert_eq!(one_level_node.drop_last().map(|n| n.used()), Some(1));
+        assert_eq!(one_level_node.drop_last(), Some(()));
+        assert_eq!(one_level_node.used(), 1);
     }
 
     #[test]
     fn test_drop_last_multi_level() -> () {
-        let node_three: Node<u32> = Vector::new_with_bits(1)
+        let mut node_three: Node<u32> = Vector::new_with_bits(1)
             .push_back(0)
             .push_back(1)
             .push_back(2)
             .root
             .as_ref()
             .clone();
-        let node_four: Node<u32> = Vector::new_with_bits(1)
+        let mut node_four: Node<u32> = Vector::new_with_bits(1)
             .push_back(0)
             .push_back(1)
             .push_back(2)
@@ -117,8 +118,10 @@ mod node {
             Node::Branch(a_branch)
         };
 
-        assert_eq!(node_three.drop_last(), Some(node_three_after_drop));
-        assert_eq!(node_four.drop_last(), Some(node_four_after_drop));
+        assert_eq!(node_three.drop_last(), Some(()));
+        assert_eq!(node_three, node_three_after_drop);
+        assert_eq!(node_four.drop_last(), Some(()));
+        assert_eq!(node_four, node_four_after_drop);
     }
 }
 
@@ -368,19 +371,19 @@ mod internal {
             (Node::Branch(a_branch), leaf)
         };
 
-        assert_eq!(empty_leaf.clone(), Vector::compress_root(empty_leaf));
-        assert_eq!(empty_branch.clone(), Vector::compress_root(empty_branch));
+        assert_eq!(empty_leaf.clone(), *Vector::compress_root(empty_leaf));
+        assert_eq!(empty_branch.clone(), *Vector::compress_root(empty_branch));
         assert_eq!(
             singleton_leaf.clone(),
-            Vector::compress_root(singleton_leaf)
+            *Vector::compress_root(singleton_leaf)
         );
         assert_eq!(
             compressed_branch.clone(),
-            Vector::compress_root(compressed_branch)
+            *Vector::compress_root(compressed_branch)
         );
         assert_eq!(
             uncompressed_branch_leaf,
-            Vector::compress_root(uncompressed_branch)
+            *Vector::compress_root(uncompressed_branch)
         );
     }
 


### PR DESCRIPTION
POC of using `Arc::make_mut` to avoid allocating new `Arc`s
unnecesarily. Can speedup mutating operations quite significantly on
certain workloads.

The same approach could be used on most or all of the other
datastructures as well though the difficulty of rewriting may vary.

### Before
```
running 4 tests
test vector_drop_last ... bench: 130,201,140 ns/iter (+/- 36,244,874)
test vector_get       ... bench:   1,184,598 ns/iter (+/- 1,617,973)
test vector_iterate   ... bench:     867,704 ns/iter (+/- 1,049,963)
test vector_push_back ... bench: 144,737,691 ns/iter (+/- 37,627,413)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```

### After
```
running 6 tests
test vector_drop_last     ... bench: 121,274,205 ns/iter (+/- 42,464,999)
test vector_drop_last_mut ... bench:   6,236,952 ns/iter (+/- 5,259,908)
test vector_get           ... bench:   1,346,970 ns/iter (+/- 1,673,853)
test vector_iterate       ... bench:     941,329 ns/iter (+/- 1,300,796)
test vector_push_back     ... bench: 166,950,667 ns/iter (+/- 50,590,077)
test vector_push_back_mut ... bench:  12,237,360 ns/iter (+/- 8,773,744)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured
```

```
$ cargo benchcmp old new
 name              old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 vector_drop_last  130,201,140  110,503,419   -19,697,721  -15.13%   x 1.18
 vector_get        1,184,598    1,143,228         -41,370   -3.49%   x 1.04
 vector_iterate    867,704      888,491            20,787    2.40%   x 0.98
 vector_push_back  144,737,691  128,403,711   -16,333,980  -11.29%   x 1.13
```