### PR TITLE
[POC] Remove Arc wrapping of keys and values in Vector and RedBlackTree

### DIFF
--- a/benches/rpds_red_black_tree_map.rs
+++ b/benches/rpds_red_black_tree_map.rs
@@ -17,7 +17,7 @@ use utils::BencherNoDrop;
 use utils::iterations;
 
 fn red_black_tree_map_insert(bench: &mut Bencher) -> () {
-    let limit = iterations(100_000);
+    let limit = iterations(10_000);
 
     bench.iter_no_drop(|| {
         let mut map = RedBlackTreeMap::new();
@@ -31,7 +31,7 @@ fn red_black_tree_map_insert(bench: &mut Bencher) -> () {
 }
 
 fn red_black_tree_map_remove(bench: &mut Bencher) -> () {
-    let limit = iterations(100_000);
+    let limit = iterations(10_000);
     let mut full_map = RedBlackTreeMap::new();
 
     for i in 0..limit {
@@ -50,7 +50,7 @@ fn red_black_tree_map_remove(bench: &mut Bencher) -> () {
 }
 
 fn red_black_tree_map_get(bench: &mut Bencher) -> () {
-    let limit = iterations(100_000);
+    let limit = iterations(10_000);
     let mut map = RedBlackTreeMap::new();
 
     for i in 0..limit {
@@ -65,7 +65,7 @@ fn red_black_tree_map_get(bench: &mut Bencher) -> () {
 }
 
 fn red_black_tree_map_iterate(bench: &mut Bencher) -> () {
-    let limit = iterations(100_000);
+    let limit = iterations(10_000);
     let mut map = RedBlackTreeMap::new();
 
     for i in 0..limit {

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Entry<K, V> {
-    pub key:   K,
+    pub key: K,
     pub value: V,
 }
 

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -21,7 +21,7 @@ impl<K, V> Node<K, V> {
         Node {
             entry: Arc::new(entry),
             color: Color::Black,
-            left:  None,
+            left: None,
             right: None,
         }
     }
@@ -122,14 +122,14 @@ mod node {
     use super::*;
 
     fn dummy_entry(v: i32) -> Entry<i32, i32> {
-        Entry { key:   v, value: v }
+        Entry { key: v, value: v }
     }
 
     fn dummy_leaf(v: i32) -> Node<i32, i32> {
         Node {
             entry: Arc::new(dummy_entry(v)),
             color: Color::Red,
-            left:  None,
+            left: None,
             right: None,
         }
     }
@@ -142,7 +142,7 @@ mod node {
         Node {
             entry: Arc::new(dummy_entry(v)),
             color: Color::Red,
-            left:  left.map(|n| Arc::new(n)),
+            left: left.map(|n| Arc::new(n)),
             right: right.map(|n| Arc::new(n)),
         }
     }
@@ -278,13 +278,13 @@ mod node {
         let tree_case_1 = Node {
             entry: Arc::clone(&entry_z),
             color: Color::Black,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_y),
                 color: Color::Red,
-                left:  Some(Arc::new(Node {
+                left: Some(Arc::new(Node {
                     entry: Arc::clone(&entry_x),
                     color: Color::Red,
-                    left:  Some(Arc::clone(&tree_a)),
+                    left: Some(Arc::clone(&tree_a)),
                     right: Some(Arc::clone(&tree_b)),
                 })),
                 right: Some(Arc::clone(&tree_c)),
@@ -295,14 +295,14 @@ mod node {
         let tree_case_2 = Node {
             entry: Arc::clone(&entry_z),
             color: Color::Black,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_x),
                 color: Color::Red,
-                left:  Some(Arc::clone(&tree_a)),
+                left: Some(Arc::clone(&tree_a)),
                 right: Some(Arc::new(Node {
                     entry: Arc::clone(&entry_y),
                     color: Color::Red,
-                    left:  Some(Arc::clone(&tree_b)),
+                    left: Some(Arc::clone(&tree_b)),
                     right: Some(Arc::clone(&tree_c)),
                 })),
             })),
@@ -312,14 +312,14 @@ mod node {
         let tree_case_3 = Node {
             entry: Arc::clone(&entry_x),
             color: Color::Black,
-            left:  Some(Arc::clone(&tree_a)),
+            left: Some(Arc::clone(&tree_a)),
             right: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_z),
                 color: Color::Red,
-                left:  Some(Arc::new(Node {
+                left: Some(Arc::new(Node {
                     entry: Arc::clone(&entry_y),
                     color: Color::Red,
-                    left:  Some(Arc::clone(&tree_b)),
+                    left: Some(Arc::clone(&tree_b)),
                     right: Some(Arc::clone(&tree_c)),
                 })),
                 right: Some(Arc::clone(&tree_d)),
@@ -329,15 +329,15 @@ mod node {
         let tree_case_4 = Node {
             entry: Arc::clone(&entry_x),
             color: Color::Black,
-            left:  Some(Arc::clone(&tree_a)),
+            left: Some(Arc::clone(&tree_a)),
             right: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_y),
                 color: Color::Red,
-                left:  Some(Arc::clone(&tree_b)),
+                left: Some(Arc::clone(&tree_b)),
                 right: Some(Arc::new(Node {
                     entry: Arc::clone(&entry_z),
                     color: Color::Red,
-                    left:  Some(Arc::clone(&tree_c)),
+                    left: Some(Arc::clone(&tree_c)),
                     right: Some(Arc::clone(&tree_d)),
                 })),
             })),
@@ -346,13 +346,13 @@ mod node {
         let tree_none_of_the_above = Node {
             entry: Arc::clone(&entry_z),
             color: Color::Black,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_y),
                 color: Color::Red,
-                left:  Some(Arc::new(Node {
+                left: Some(Arc::new(Node {
                     entry: Arc::clone(&entry_x),
                     color: Color::Black,
-                    left:  Some(Arc::clone(&tree_a)),
+                    left: Some(Arc::clone(&tree_a)),
                     right: Some(Arc::clone(&tree_b)),
                 })),
                 right: Some(Arc::clone(&tree_c)),
@@ -363,16 +363,16 @@ mod node {
         let tree_balanced = Node {
             entry: Arc::clone(&entry_y),
             color: Color::Red,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_x),
                 color: Color::Black,
-                left:  Some(Arc::clone(&tree_a)),
+                left: Some(Arc::clone(&tree_a)),
                 right: Some(Arc::clone(&tree_b)),
             })),
             right: Some(Arc::new(Node {
                 entry: Arc::clone(&entry_z),
                 color: Color::Black,
-                left:  Some(Arc::clone(&tree_c)),
+                left: Some(Arc::clone(&tree_c)),
                 right: Some(Arc::clone(&tree_d)),
             })),
         };
@@ -406,11 +406,11 @@ mod node {
         let expected_node = Node {
             entry: Arc::new(Entry::new(0, 2)),
             color: Color::Black,
-            left:  None,
+            left: None,
             right: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(10, 3)),
                 color: Color::Red,
-                left:  None,
+                left: None,
                 right: None,
             })),
         };
@@ -422,11 +422,11 @@ mod node {
         let expected_node = Node {
             entry: Arc::new(Entry::new(0, 2)),
             color: Color::Black,
-            left:  None,
+            left: None,
             right: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(10, 4)),
                 color: Color::Red,
-                left:  None,
+                left: None,
                 right: None,
             })),
         };
@@ -439,16 +439,16 @@ mod node {
         let expected_node = Node {
             entry: Arc::new(Entry::new(5, 5)),
             color: Color::Black,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(0, 2)),
                 color: Color::Black,
-                left:  None,
+                left: None,
                 right: None,
             })),
             right: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(10, 4)),
                 color: Color::Black,
-                left:  None,
+                left: None,
                 right: None,
             })),
         };
@@ -461,16 +461,16 @@ mod node {
         let expected_node = Node {
             entry: Arc::new(Entry::new(5, 5)),
             color: Color::Black,
-            left:  Some(Arc::new(Node {
+            left: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(0, 1)),
                 color: Color::Black,
-                left:  None,
+                left: None,
                 right: None,
             })),
             right: Some(Arc::new(Node {
                 entry: Arc::new(Entry::new(10, 4)),
                 color: Color::Black,
-                left:  None,
+                left: None,
                 right: None,
             })),
         };

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -84,22 +84,6 @@ where
         }
     }
 
-    pub fn insert(&self, v: T) -> RedBlackTreeSet<T> {
-        RedBlackTreeSet {
-            map: self.map.insert(v, ()),
-        }
-    }
-
-    pub fn remove<V: ?Sized>(&self, v: &V) -> RedBlackTreeSet<T>
-    where
-        T: Borrow<V>,
-        V: Ord,
-    {
-        RedBlackTreeSet {
-            map: self.map.remove(v),
-        }
-    }
-
     pub fn contains<V: ?Sized>(&self, v: &V) -> bool
     where
         T: Borrow<V>,
@@ -169,6 +153,27 @@ where
 
     pub fn iter(&self) -> Iter<T> {
         self.map.keys()
+    }
+}
+
+impl<T> RedBlackTreeSet<T>
+where
+    T: Ord + Clone,
+{
+    pub fn insert(&self, v: T) -> RedBlackTreeSet<T> {
+        RedBlackTreeSet {
+            map: self.map.insert(v, ()),
+        }
+    }
+
+    pub fn remove<V: ?Sized>(&self, v: &V) -> RedBlackTreeSet<T>
+    where
+        T: Borrow<V>,
+        V: Ord,
+    {
+        RedBlackTreeSet {
+            map: self.map.remove(v),
+        }
     }
 }
 
@@ -243,7 +248,7 @@ where
 // TODO This can be improved to create a perfectly balanced tree.
 impl<T> FromIterator<T> for RedBlackTreeSet<T>
 where
-    T: Ord,
+    T: Ord + Clone,
 {
     fn from_iter<I: IntoIterator<Item = T>>(into_iter: I) -> RedBlackTreeSet<T> {
         let mut map = RedBlackTreeSet::new();


### PR DESCRIPTION
Vectors seem promising but the RedBlackTree regresses in get and iterate which is rather odd... Need to investigate further.

```
 name                  old ns/iter  new ns/iter  diff ns/iter   diff %  speedup 
 vector_drop_last      120,354,099  95,403,062    -24,951,037  -20.73%   x 1.26 
 vector_drop_last_mut  7,469,591    5,451,750      -2,017,841  -27.01%   x 1.37 
 vector_get            2,969,756    2,909,477         -60,279   -2.03%   x 1.02 
 vector_iterate        1,411,878    1,269,607        -142,271  -10.08%   x 1.11 
 vector_push_back      131,497,470  103,677,766   -27,819,704  -21.16%   x 1.27 
 vector_push_back_mut  14,291,589   9,912,382      -4,379,207  -30.64%   x 1.44 
```

(10k elements)
```
 name                        old_tree ns/iter  new_tree ns/iter  diff ns/iter   diff %  speedup 
 red_black_tree_map_get      624,572           667,942                 43,370    6.94%   x 0.94 
 red_black_tree_map_insert   17,937,010        15,219,633          -2,717,377  -15.15%   x 1.18 
 red_black_tree_map_iterate  172,588           197,880                 25,292   14.65%   x 0.87 
 red_black_tree_map_remove   22,687,565        18,574,023          -4,113,542  -18.13%   x 1.22 
```

```
```