### PR TITLE
Provide IndexMut for Vector<T: Clone> (Issue #30)

### DIFF
--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -461,6 +461,8 @@ impl<T> Vector<T> {
 }
 
 impl<T: Clone> Vector<T> {
+    /// Gets a mutable reference to an element. If the element is shared, this Vector will be cloned.
+    /// Returns **None** if and only if the given **index** is out of range.
     #[must_use]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         if index >= self.length {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -201,7 +201,12 @@ impl<T> Node<T> {
 }
 
 impl<T: Clone> Node<T> {
-    fn get_mut<F: Fn(usize, usize) -> usize>(&mut self, index: usize, height: usize, bucket: F) -> &mut T {
+    fn get_mut<F: Fn(usize, usize) -> usize>(
+        &mut self,
+        index: usize,
+        height: usize,
+        bucket: F,
+    ) -> &mut T {
         let b = bucket(index, height);
 
         match *self {
@@ -213,7 +218,6 @@ impl<T: Clone> Node<T> {
         }
     }
 }
-
 
 impl<T> Clone for Node<T> {
     fn clone(&self) -> Node<T> {
@@ -471,11 +475,9 @@ impl<T: Clone> Vector<T> {
             let height = self.height();
             let bits = self.bits;
             Some(
-                Arc::make_mut(&mut self.root).get_mut(
-                    index,
-                    height,
-                    |index, height| { vector_utils::bucket(bits, index, height) }
-                )
+                Arc::make_mut(&mut self.root).get_mut(index, height, |index, height| {
+                    vector_utils::bucket(bits, index, height)
+                }),
             )
         }
     }
@@ -491,7 +493,6 @@ impl<T> Index<usize> for Vector<T> {
 }
 
 impl<T: Clone> IndexMut<usize> for Vector<T> {
-
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index)
             .expect(&format!("index out of bounds {}", index))

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -465,8 +465,8 @@ impl<T> Vector<T> {
 }
 
 impl<T: Clone> Vector<T> {
-    /// Gets a mutable reference to an element. If the element is shared, this Vector will be cloned.
-    /// Returns **None** if and only if the given **index** is out of range.
+    /// Gets a mutable reference to an element. If the element is shared, it will be cloned.
+    /// Returns `None` if and only if the given `index` is out of range.
     #[must_use]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         if index >= self.length {
@@ -505,16 +505,16 @@ impl<T> Default for Vector<T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for Vector<T> {
-    fn eq(&self, other: &Vector<T>) -> bool {
+impl<T: PartialEq<U>, U> PartialEq<Vector<U>> for Vector<T> {
+    fn eq(&self, other: &Vector<U>) -> bool {
         self.length == other.length && self.iter().eq(other.iter())
     }
 }
 
 impl<T: Eq> Eq for Vector<T> {}
 
-impl<T: PartialOrd<T>> PartialOrd<Vector<T>> for Vector<T> {
-    fn partial_cmp(&self, other: &Vector<T>) -> Option<Ordering> {
+impl<T: PartialOrd<U>, U> PartialOrd<Vector<U>> for Vector<T> {
+    fn partial_cmp(&self, other: &Vector<U>) -> Option<Ordering> {
         self.iter().partial_cmp(other.iter())
     }
 }

--- a/src/vector/test.rs
+++ b/src/vector/test.rs
@@ -693,6 +693,9 @@ fn test_index_mut() {
     v2[4] = String::from("cloning");
     v2[5].make_ascii_uppercase();
 
+    let len = v2.len();
+    assert_eq!(v2.get_mut(len), None);
+
     for i in 0..v1.len() {
         println!("{}\t{}\t{}\t{}", v1[i], expected1[i], v2[i], expected2[i]);
         assert_eq!(v1[i], expected1[i]);

--- a/src/vector/test.rs
+++ b/src/vector/test.rs
@@ -675,6 +675,31 @@ fn test_clone() {
     assert!(clone.iter().eq(vector.iter()));
 }
 
+#[test]
+fn test_index_mut() {
+    let v1 = vector![
+        String::from("This"),
+        String::from("is"),
+        String::from("where"),
+        String::from("the"),
+        String::from("fun"),
+        String::from("begins!")
+        ];
+    let mut v2 = v1.clone();
+    let expected1 = vector!["This", "is", "where", "the", "fun", "begins!"];
+    let expected2 = vector!["That", "is", "where", "the", "cloning", "BEGINS!"];
+
+    v2[0] = "That".into();
+    v2[4] = String::from("cloning");
+    v2[5].make_ascii_uppercase();
+
+    for i in 0..v1.len() {
+        println!("{}\t{}\t{}\t{}", v1[i], expected1[i], v2[i], expected2[i]);
+        assert_eq!(v1[i], expected1[i]);
+        assert_eq!(v2[i], expected2[i]);
+    } 
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn test_serde() {

--- a/src/vector/test.rs
+++ b/src/vector/test.rs
@@ -684,7 +684,7 @@ fn test_index_mut() {
         String::from("the"),
         String::from("fun"),
         String::from("begins!")
-        ];
+    ];
     let mut v2 = v1.clone();
     let expected1 = vector!["This", "is", "where", "the", "fun", "begins!"];
     let expected2 = vector!["That", "is", "where", "the", "cloning", "BEGINS!"];
@@ -697,7 +697,7 @@ fn test_index_mut() {
         println!("{}\t{}\t{}\t{}", v1[i], expected1[i], v2[i], expected2[i]);
         assert_eq!(v1[i], expected1[i]);
         assert_eq!(v2[i], expected2[i]);
-    } 
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/vector/test.rs
+++ b/src/vector/test.rs
@@ -696,11 +696,8 @@ fn test_index_mut() {
     let len = v2.len();
     assert_eq!(v2.get_mut(len), None);
 
-    for i in 0..v1.len() {
-        println!("{}\t{}\t{}\t{}", v1[i], expected1[i], v2[i], expected2[i]);
-        assert_eq!(v1[i], expected1[i]);
-        assert_eq!(v2[i], expected2[i]);
-    }
+    assert_eq!(v1, expected1);
+    assert_eq!(v2, expected2);
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Here's some work towards #30. I don't think its possible to implement  for Vector<T: !Clone>.

I'm pretty new to Rust, so any constructive criticism would be appreciated.