### PR TITLE
Add RedBlackTree::range

### DIFF
--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -919,14 +919,15 @@ where
         use std::ops::Bound::*;
 
         match (range.start_bound(), range.end_bound()) {
-            (Excluded(s), Excluded(e)) if s==e =>
+            (Excluded(s), Excluded(e)) if s == e =>
                 panic!("range start and end are equal and excluded in RedBlackTreeMap"),
-            (Included(s), Included(e)) |
-            (Included(s), Excluded(e)) |
-            (Excluded(s), Included(e)) |
-            (Excluded(s), Excluded(e)) if s>e =>
+            (Included(s), Included(e))
+            | (Included(s), Excluded(e))
+            | (Excluded(s), Included(e))
+            | (Excluded(s), Excluded(e))
+                if s > e =>
                 panic!("range start is greater than range end in RedBlackTreeMap"),
-            _ => {},
+            _ => {}
         };
         RangeIter::new(self, range)
     }
@@ -1086,7 +1087,9 @@ impl<'a, K: Ord, V> Stack<'a, K, V> {
     fn new(map: &'a RedBlackTreeMap<K, V>) -> Stack<'a, K, V> {
         let size = iter_utils::conservative_height(map.size()) + 1;
 
-        Stack { stack: Vec::with_capacity(size) }
+        Stack {
+            stack: Vec::with_capacity(size),
+        }
     }
 
     #[inline]
@@ -1132,7 +1135,11 @@ impl<'a, K: Ord, V> Stack<'a, K, V> {
             self.stack.push(cur_node);
         }
 
-        let child = if good == backwards { &cur_node.right } else { &cur_node.left };
+        let child = if good == backwards {
+            &cur_node.right
+        } else {
+            &cur_node.left
+        };
         if let Some(c) = child {
             self.dig_towards(c.borrow(), target, backwards);
         }
@@ -1298,18 +1305,20 @@ impl<'a, K: Ord, V> RangeIter<'a, K, V> {
         };
 
         RangeIter {
-            map: map,
+            map,
             stack_forward: forward,
             stack_backward: backward,
-            done: done,
+            done,
         }
     }
 
     // Checks if the forwards and backwards stacks are pointing to the same entry. If they are, it
     // means that yielding one more element will terminate the iteration.
     fn almost_done(&self) -> bool {
-        let ptr = |stack: &Stack<_,_>| {
-            stack.current().map(|arc| arc.borrow() as *const Entry<_,_>)
+        let ptr = |stack: &Stack<_, _>| {
+            stack
+                .current()
+                .map(|arc| arc.borrow() as *const Entry<_, _>)
         };
         ptr(&self.stack_forward) == ptr(&self.stack_backward)
     }

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -65,7 +65,7 @@ macro_rules! rbt_map {
 /// | `contains_key()`           |      Θ(1) | Θ(log(n)) |   Θ(log(n)) |
 /// | `size()`                   |      Θ(1) |      Θ(1) |        Θ(1) |
 /// | `clone()`                  |      Θ(1) |      Θ(1) |        Θ(1) |
-/// | iterator creation          |      Θ(1) |      Θ(1) |        Θ(1) |
+/// | iterator creation          |      Θ(1) | Θ(log(n)) |   Θ(log(n)) |
 /// | iterator step              |      Θ(1) |      Θ(1) |   Θ(log(n)) |
 /// | iterator full              |      Θ(n) |      Θ(n) |        Θ(n) |
 ///

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1156,38 +1156,6 @@ where
     fn non_empty(&self) -> bool {
         self.left_index < self.right_index
     }
-
-    fn advance_forward(&mut self) {
-        if self.non_empty() {
-            self.stack_forward.as_mut().unwrap().advance(false);
-
-            self.left_index += 1;
-        }
-    }
-
-    fn current_forward(&mut self) -> Option<&'a Arc<Entry<K, V>>> {
-        if self.non_empty() {
-            self.stack_forward.as_ref().unwrap().current()
-        } else {
-            None
-        }
-    }
-
-    fn advance_backward(&mut self) {
-        if self.non_empty() {
-            self.stack_backward.as_mut().unwrap().advance(true);
-
-            self.right_index -= 1;
-        }
-    }
-
-    fn current_backward(&mut self) -> Option<&'a Arc<Entry<K, V>>> {
-        if self.non_empty() {
-            self.stack_backward.as_ref().unwrap().current()
-        } else {
-            None
-        }
-    }
 }
 
 impl<'a, K, V> Iterator for IterArc<'a, K, V>
@@ -1199,11 +1167,15 @@ where
     fn next(&mut self) -> Option<&'a Arc<Entry<K, V>>> {
         self.init_if_needed(false);
 
-        let current = self.current_forward();
+        if self.non_empty() {
+            let current = self.stack_forward.as_ref().unwrap().current();
+            self.stack_forward.as_mut().unwrap().advance(false);
+            self.left_index += 1;
 
-        self.advance_forward();
-
-        current
+            current
+        } else {
+            None
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1220,11 +1192,15 @@ where
     fn next_back(&mut self) -> Option<&'a Arc<Entry<K, V>>> {
         self.init_if_needed(true);
 
-        let current = self.current_backward();
+        if self.non_empty() {
+            let current = self.stack_backward.as_ref().unwrap().current();
+            self.stack_backward.as_mut().unwrap().advance(true);
+            self.right_index -= 1;
 
-        self.advance_backward();
-
-        current
+            current
+        } else {
+            None
+        }
     }
 }
 

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1288,20 +1288,34 @@ mod iter {
             3 => 6
         ];
 
-        macro_rules! cmp {
-            ($range:expr, $expected:expr) => {
-                assert_eq!(
-                    map.range($range).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
-                    $expected
-                );
-            };
+        fn cmp<RB: RangeBounds<i32> + Clone>(
+            map: &RedBlackTreeMap<i32, i32>,
+            range: RB,
+            expected: Vec<(i32, i32)>,
+        ) {
+            assert_eq!(
+                map.range(range.clone())
+                    .map(|(k, v)| (*k, *v))
+                    .collect::<Vec<_>>(),
+                expected
+            );
+            assert_eq!(
+                map.range(range)
+                    .rev()
+                    .map(|(k, v)| (*k, *v))
+                    .collect::<Vec<_>>(),
+                expected.iter().cloned().rev().collect::<Vec<_>>()
+            );
         }
 
-        cmp!(.., vec![(0, 0), (1, 2), (2, 4), (3, 6)]);
-        cmp!(1.., vec![(1, 2), (2, 4), (3, 6)]);
-        cmp!(1..3, vec![(1, 2), (2, 4)]);
-        cmp!(1..=3, vec![(1, 2), (2, 4), (3, 6)]);
-        cmp!(..3, vec![(0, 0), (1, 2), (2, 4)]);
+        cmp(&map, .., vec![(0, 0), (1, 2), (2, 4), (3, 6)]);
+        cmp(&map, 1.., vec![(1, 2), (2, 4), (3, 6)]);
+        cmp(&map, 1..3, vec![(1, 2), (2, 4)]);
+        cmp(&map, 1..=3, vec![(1, 2), (2, 4), (3, 6)]);
+        cmp(&map, ..3, vec![(0, 0), (1, 2), (2, 4)]);
+
+        use std::ops::Bound::*;
+        cmp(&map, (Excluded(1), Included(3)), vec![(2, 4), (3, 6)]);
     }
 
     #[test]

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1278,6 +1278,44 @@ mod iter {
 
         assert_eq!(left, 0);
     }
+
+    #[test]
+    fn test_range() {
+        let map = rbt_map![
+            0 => 0,
+            1 => 2,
+            2 => 4,
+            3 => 6
+        ];
+
+        macro_rules! cmp {
+            ($range:expr, $expected:expr) => {
+                assert_eq!(map.range($range).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(), $expected);
+            }
+        }
+
+        cmp!(.., vec![(0, 0), (1, 2), (2, 4), (3, 6)]);
+        cmp!(1.., vec![(1, 2), (2, 4), (3, 6)]);
+        cmp!(1..3, vec![(1, 2), (2, 4)]);
+        cmp!(1..=3, vec![(1, 2), (2, 4), (3, 6)]);
+        cmp!(..3, vec![(0, 0), (1, 2), (2, 4)]);
+    }
+
+    #[test]
+    fn test_range_empty() {
+        let map = rbt_map![
+            0 => 0,
+            1 => 2,
+            10 => 20,
+            11 => 22
+        ];
+
+        assert_eq!(map.range(1..1).next(), None);
+        assert_eq!(map.range(3..10).next(), None);
+        assert_eq!(map.range(..0).next(), None);
+        assert_eq!(map.range(3..=9).next(), None);
+        assert_eq!(map.range(13..).next(), None);
+    }
 }
 
 mod compile_time {

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1290,8 +1290,11 @@ mod iter {
 
         macro_rules! cmp {
             ($range:expr, $expected:expr) => {
-                assert_eq!(map.range($range).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(), $expected);
-            }
+                assert_eq!(
+                    map.range($range).map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+                    $expected
+                );
+            };
         }
 
         cmp!(.., vec![(0, 0), (1, 2), (2, 4), (3, 6)]);

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -58,7 +58,7 @@ macro_rules! rbt_set {
 /// | `contains()`               |      Θ(1) | Θ(log(n)) |   Θ(log(n)) |
 /// | `size()`                   |      Θ(1) |      Θ(1) |        Θ(1) |
 /// | `clone()`                  |      Θ(1) |      Θ(1) |        Θ(1) |
-/// | iterator creation          |      Θ(1) |      Θ(1) |        Θ(1) |
+/// | iterator creation          |      Θ(1) | Θ(log(n)) |   Θ(log(n)) |
 /// | iterator step              |      Θ(1) |      Θ(1) |   Θ(log(n)) |
 /// | iterator full              |      Θ(n) |      Θ(n) |        Θ(n) |
 ///


### PR DESCRIPTION
This implementation is based on the suggestion in #23, but I ended up diverging a bit from that. In particular, I'm not implementing IterArc in terms of RangeIter, because the termination logic ended up being different and so there wasn't much code-sharing to be had. Also, the logic in RangeIter is much nicer if I don't include the lazy-initialization optimization for the stacks.

I did, however, attempt to reuse some code between IterArc and RangeIter by factoring out some utilities for managing the stacks.