### PR TITLE
preventing stack overflow when dropping List.

### DIFF
--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -398,6 +398,23 @@ where
     }
 }
 
+impl<T, P> Drop for List<T, P>
+where
+    P: SharedPointerKind,
+{
+    fn drop(&mut self) {
+        let mut head = self.head.take();
+        while let Some(node) = head {
+            if let Ok(mut node) = SharedPointer::try_unwrap(node) {
+                head = node.next.take();
+            }
+            else {
+                break;
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct IterPtr<'a, T, P>
 where

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -407,8 +407,7 @@ where
         while let Some(node) = head {
             if let Ok(mut node) = SharedPointer::try_unwrap(node) {
                 head = node.next.take();
-            }
-            else {
+            } else {
                 break;
             }
         }

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -398,6 +398,7 @@ where
     }
 }
 
+// drop list non-recursively to prevent stack overflow.
 impl<T, P> Drop for List<T, P>
 where
     P: SharedPointerKind,

--- a/src/list/test.rs
+++ b/src/list/test.rs
@@ -25,7 +25,7 @@ mod iter {
     #[test]
     fn test_drop_list() {
         // When it is dropped, it will set the variable it owned to false.
-        struct DropStruct<'a> (&'a mut bool);
+        struct DropStruct<'a>(&'a mut bool);
         impl<'a> Drop for DropStruct<'a> {
             fn drop(&mut self) {
                 *self.0 = false;

--- a/src/list/test.rs
+++ b/src/list/test.rs
@@ -23,6 +23,71 @@ mod iter {
     use pretty_assertions::assert_eq;
 
     #[test]
+    fn test_drop_list() {
+        // When it is dropped, it will set the variable it owned to false.
+        struct DropStruct<'a> (&'a mut bool);
+        impl<'a> Drop for DropStruct<'a> {
+            fn drop(&mut self) {
+                *self.0 = false;
+            }
+        }
+
+        // test that we actually dropped the elements
+        let (mut a, mut b, mut c, mut d, mut e) = (true, true, true, true, true);
+        let (pa, pb, pc, pd, pe) = (
+            &a as *const bool,
+            &b as *const bool,
+            &c as *const bool,
+            &d as *const bool,
+            &e as *const bool,
+        );
+
+        let mut x = List::new();
+        x.push_front_mut(DropStruct(&mut a));
+        x.push_front_mut(DropStruct(&mut b));
+        x.push_front_mut(DropStruct(&mut c));
+
+        unsafe {
+            assert_eq!(vec![*pa, *pb, *pc, *pd, *pe], vec![true, true, true, true, true]);
+        }
+
+        let x2 = x.drop_first().unwrap().drop_first().unwrap();
+
+        drop(x);
+        unsafe {
+            assert_eq!(vec![*pa, *pb, *pc, *pd, *pe], vec![true, false, false, true, true]);
+        }
+
+        let y = x2.push_front(DropStruct(&mut d));
+
+        drop(x2);
+        unsafe {
+            assert_eq!(vec![*pa, *pb, *pc, *pd, *pe], vec![true, false, false, true, true]);
+        }
+
+        let z = y.push_front(DropStruct(&mut e));
+
+        drop(y);
+        unsafe {
+            assert_eq!(vec![*pa, *pb, *pc, *pd, *pe], vec![true, false, false, true, true]);
+        }
+
+        drop(z);
+        unsafe {
+            assert_eq!(vec![*pa, *pb, *pc, *pd, *pe], vec![false, false, false, false, false]);
+        }
+    }
+
+    #[test]
+    fn test_drop_large() {
+        let limit = 1024 * 1024;
+        let mut list = List::new();
+        for i in 0..limit {
+            list.push_front_mut(i);
+        }
+    }
+
+    #[test]
     fn test_iter() {
         let limit = 1024;
         let mut list = List::new();


### PR DESCRIPTION
 implement our custom Drop trait for List to non-recursively drop the List. #46 