### PR TITLE
Add get_mut() to maps

### DIFF
--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -280,6 +280,19 @@ where
     }
 }
 
+impl<T, P> List<T, P>
+where
+    T: Clone,
+    P: SharedPointerKind,
+{
+    #[must_use]
+    pub(crate) fn first_mut(&mut self) -> Option<&mut T> {
+        self.head
+            .as_mut()
+            .map(|node| SharedPointer::make_mut(&mut SharedPointer::make_mut(node).value))
+    }
+}
+
 impl<T, P> Default for List<T, P>
 where
     P: SharedPointerKind,

--- a/src/list/test.rs
+++ b/src/list/test.rs
@@ -114,6 +114,18 @@ fn test_first() {
 }
 
 #[test]
+fn test_first_mut() {
+    let a = list![0, 1, 2, 3];
+    let mut b = a.clone();
+    *b.first_mut().unwrap() = -1;
+
+    assert_eq!(a.first(), Some(&0));
+    assert_eq!(b.first(), Some(&-1));
+    assert!(a.iter().eq(vec![0, 1, 2, 3].iter()));
+    assert!(b.iter().eq(vec![-1, 1, 2, 3].iter()));
+}
+
+#[test]
 fn test_last() {
     let empty_list: List<i32> = List::new();
     let mut singleton_list = list!["hello"];

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Entry<K, V> {
     pub key: K,
     pub value: V,

--- a/src/map/hash_trie_map/test.rs
+++ b/src/map/hash_trie_map/test.rs
@@ -73,19 +73,19 @@ mod bucket {
         let list_a_b = list_sync!['a', 'b'];
 
         let mut list = list_a_b_c.clone();
-        assert!(!list_remove_first(&mut list, |_| false));
+        assert!(list_remove_first(&mut list, |_| false).is_none());
         assert_eq!(list, list_a_b_c);
 
         let mut list = list_a_b_c.clone();
-        assert!(list_remove_first(&mut list, |c| *c == 'a'));
+        assert!(list_remove_first(&mut list, |c| *c == 'a').is_some());
         assert_eq!(list, list_b_c);
 
         let mut list = list_a_b_c.clone();
-        assert!(list_remove_first(&mut list, |c| *c == 'b'));
+        assert!(list_remove_first(&mut list, |c| *c == 'b').is_some());
         assert_eq!(list, list_a_c);
 
         let mut list = list_a_b_c.clone();
-        assert!(list_remove_first(&mut list, |c| *c == 'c'));
+        assert!(list_remove_first(&mut list, |c| *c == 'c').is_some());
         assert_eq!(list, list_a_b);
     }
 
@@ -435,6 +435,35 @@ mod node {
         assert_eq!(map.get(&0xC), Some(&2));
         assert_eq!(map.get(&0xD), Some(&3));
         assert_eq!(map.get(&0xE), Some(&4));
+        assert_eq!(map.get(&0x0), None);
+        assert_eq!(map.get(&0x1), None);
+        assert_eq!(map.get(&0x2), None);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let original = dummy_hash_trie_map();
+        let mut map = original.clone();
+
+        *map.get_mut(&0xB).unwrap() = -1;
+        *map.get_mut(&0xE).unwrap() = -1;
+        assert!(map.get_mut(&0x1).is_none());
+        assert!(map.get_mut(&0x2).is_none());
+
+        assert_eq!(original.get(&0xA), Some(&0));
+        assert_eq!(original.get(&0xB), Some(&1));
+        assert_eq!(original.get(&0xC), Some(&2));
+        assert_eq!(original.get(&0xD), Some(&3));
+        assert_eq!(original.get(&0xE), Some(&4));
+        assert_eq!(original.get(&0x0), None);
+        assert_eq!(original.get(&0x1), None);
+        assert_eq!(original.get(&0x2), None);
+
+        assert_eq!(map.get(&0xA), Some(&0));
+        assert_eq!(map.get(&0xB), Some(&-1));
+        assert_eq!(map.get(&0xC), Some(&2));
+        assert_eq!(map.get(&0xD), Some(&3));
+        assert_eq!(map.get(&0xE), Some(&-1));
         assert_eq!(map.get(&0x0), None);
         assert_eq!(map.get(&0x1), None);
         assert_eq!(map.get(&0x2), None);

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -198,10 +198,32 @@ mod node {
     fn test_get() {
         let tree = dummy_tree_0_1_2_3();
 
-        assert_eq!(tree.get(&0).unwrap().key, 0);
-        assert_eq!(tree.get(&1).unwrap().key, 1);
-        assert_eq!(tree.get(&2).unwrap().key, 2);
-        assert_eq!(tree.get(&3).unwrap().key, 3);
+        assert_eq!(tree.get(&0).unwrap().value, 0);
+        assert_eq!(tree.get(&1).unwrap().value, 1);
+        assert_eq!(tree.get(&2).unwrap().value, 2);
+        assert_eq!(tree.get(&3).unwrap().value, 3);
+        assert_eq!(tree.get(&4), None);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let original = dummy_tree_0_1_2_3();
+        let mut tree = original.clone();
+
+        tree.get_mut(&2).unwrap().value = -2;
+        tree.get_mut(&3).unwrap().value = -3;
+        assert!(tree.get_mut(&4).is_none());
+
+        assert_eq!(original.get(&0).unwrap().value, 0);
+        assert_eq!(original.get(&1).unwrap().value, 1);
+        assert_eq!(original.get(&2).unwrap().value, 2);
+        assert_eq!(original.get(&3).unwrap().value, 3);
+        assert_eq!(original.get(&4), None);
+
+        assert_eq!(tree.get(&0).unwrap().value, 0);
+        assert_eq!(tree.get(&1).unwrap().value, 1);
+        assert_eq!(tree.get(&2).unwrap().value, -2);
+        assert_eq!(tree.get(&3).unwrap().value, -3);
         assert_eq!(tree.get(&4), None);
     }
 


### PR DESCRIPTION
With it the user can avoid the clunky pattern get() + clone + modify + insert(). Especially useful if you have early returns (eg. with `?`) in between.