### PR TITLE
Impl Hash for RedBlackTreeSet

### DIFF
--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -9,6 +9,7 @@ use archery::{ArcK, RcK, SharedPointerKind};
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::Display;
+use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
 use core::ops::RangeBounds;
 
@@ -322,6 +323,22 @@ where
 {
     fn cmp(&self, other: &RedBlackTreeSet<T, P>) -> Ordering {
         self.iter().cmp(other.iter())
+    }
+}
+
+impl<T: Hash, P: SharedPointerKind> Hash for RedBlackTreeSet<T, P>
+where
+    T: Ord,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Add the hash of length so that if two collections are added one after the other it
+        // doesn't hash to the same thing as a single collection with the same elements in the same
+        // order.
+        self.size().hash(state);
+
+        for e in self {
+            e.hash(state);
+        }
     }
 }
 

--- a/src/set/red_black_tree_set/test.rs
+++ b/src/set/red_black_tree_set/test.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
 use pretty_assertions::assert_eq;
 use static_assertions::assert_impl_all;
 
@@ -396,6 +397,37 @@ fn test_ord_pointer_kind_consistent() {
     assert!(set_a_sync >= set_a);
     assert!(set_b_sync > set_a);
     assert!(set_b_sync <= set_b);
+}
+
+fn hash<T: Ord + Hash, P>(set: &RedBlackTreeSet<T, P>) -> u64
+where
+    P: SharedPointerKind,
+{
+    #[allow(deprecated)]
+    let mut hasher = core::hash::SipHasher::new();
+
+    set.hash(&mut hasher);
+
+    hasher.finish()
+}
+
+#[test]
+fn test_hash() {
+    let set_1 = rbt_set!["a"];
+    let set_1_prime = rbt_set!["a"];
+    let set_2 = rbt_set!["b", "a"];
+
+    assert_eq!(hash(&set_1), hash(&set_1));
+    assert_eq!(hash(&set_1), hash(&set_1_prime));
+    assert_ne!(hash(&set_1), hash(&set_2));
+}
+
+#[test]
+fn test_hash_pointer_kind_consistent() {
+    let set = rbt_set!["a"];
+    let set_sync = rbt_set_sync!["a"];
+
+    assert_eq!(hash(&set), hash(&set_sync));
 }
 
 #[test]


### PR DESCRIPTION
I tried using a `RedBlackTreeSet` inside of another map and was surprised to find it doesn't impl `Hash`. Considering that you can already hash a `RedBlackTreeMap<T, ()>`, I think it makes sense to expose that functionality on the Set type here too.