### PR TITLE
Add fast-paths to rb-tree/hash-trie equality and set operations

### DIFF
--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -948,13 +948,17 @@ where
     H: Clone,
     P: SharedPointerKind,
 {
-    pub(crate) fn same_root<PO: SharedPointerKind, I: BuildHasher>(
+    /// Test whether the two maps refer to the same content in memory.
+    ///
+    /// This would return true if you’re comparing a map to itself,
+    /// or if you’re comparing a map to a fresh clone of itself.
+    pub fn ptr_eq<PO: SharedPointerKind, I: BuildHasher>(
         &self,
         other: &HashTrieMap<K, V, PO, I>,
     ) -> bool {
         let a = SharedPointer::as_ptr(&self.root).cast::<Node<K, V, P>>();
         // Note how we're casting the raw pointer changing from P to PO
-        // We cannot perform the equality it in a type safe way because the Root type depends
+        // We cannot perform the equality in a type safe way because the Root type depends
         // on P/PO, and we can't pass different types to SharedPtr::same_ptr or std::ptr::eq.
         let b = SharedPointer::as_ptr(&other.root).cast::<Node<K, V, P>>();
         core::ptr::eq(a, b)
@@ -970,7 +974,7 @@ where
     PO: SharedPointerKind,
 {
     fn eq(&self, other: &HashTrieMap<K, V, PO, H>) -> bool {
-        if self.same_root(other) {
+        if self.ptr_eq(other) {
             return true;
         }
         self.size() == other.size()

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -957,7 +957,7 @@ where
         // We cannot perform the equality it in a type safe way because the Root type depends
         // on P/PO, and we can't pass different types to SharedPtr::same_ptr or std::ptr::eq.
         let b = SharedPointer::as_ptr(&other.root).cast::<Node<K, V, P>>();
-        std::ptr::eq(a, b)
+        core::ptr::eq(a, b)
     }
 }
 

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1034,6 +1034,9 @@ where
     PO: SharedPointerKind,
 {
     fn eq(&self, other: &RedBlackTreeMap<K, V, PO>) -> bool {
+        if self.same_root(other) {
+            return true;
+        }
         self.size() == other.size()
             && self.iter().all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
     }

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1010,13 +1010,14 @@ impl<K, V, P> RedBlackTreeMap<K, V, P>
 where
     P: SharedPointerKind,
 {
-    pub(crate) fn same_root<PO: SharedPointerKind>(
-        &self,
-        other: &RedBlackTreeMap<K, V, PO>,
-    ) -> bool {
+    /// Test whether the two maps refer to the same content in memory.
+    ///
+    /// This would return true if you’re comparing a map to itself,
+    /// or if you’re comparing a map to a fresh clone of itself.
+    pub fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeMap<K, V, PO>) -> bool {
         let a = self.root.as_ref().map_or(core::ptr::null(), SharedPointer::as_ptr);
         // Note how we're casting the raw pointer changing from P to PO
-        // We cannot perform the equality it in a type safe way because the Root type depends
+        // We cannot perform the equality in a type safe way because the Root type depends
         // on P/PO, and we can't pass different types to SharedPtr::same_ptr or std::ptr::eq.
         let b = other
             .root
@@ -1034,7 +1035,7 @@ where
     PO: SharedPointerKind,
 {
     fn eq(&self, other: &RedBlackTreeMap<K, V, PO>) -> bool {
-        if self.same_root(other) {
+        if self.ptr_eq(other) {
             return true;
         }
         self.size() == other.size()

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1014,16 +1014,16 @@ where
         &self,
         other: &RedBlackTreeMap<K, V, PO>,
     ) -> bool {
-        let a = self.root.as_ref().map_or(std::ptr::null(), SharedPointer::as_ptr);
+        let a = self.root.as_ref().map_or(core::ptr::null(), SharedPointer::as_ptr);
         // Note how we're casting the raw pointer changing from P to PO
         // We cannot perform the equality it in a type safe way because the Root type depends
         // on P/PO, and we can't pass different types to SharedPtr::same_ptr or std::ptr::eq.
         let b = other
             .root
             .as_ref()
-            .map_or(std::ptr::null(), SharedPointer::as_ptr)
+            .map_or(core::ptr::null(), SharedPointer::as_ptr)
             .cast::<Node<K, V, P>>();
-        std::ptr::eq(a, b)
+        core::ptr::eq(a, b)
     }
 }
 

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1006,6 +1006,27 @@ where
     }
 }
 
+impl<K, V, P> RedBlackTreeMap<K, V, P>
+where
+    P: SharedPointerKind,
+{
+    pub(crate) fn same_root<PO: SharedPointerKind>(
+        &self,
+        other: &RedBlackTreeMap<K, V, PO>,
+    ) -> bool {
+        let a = self.root.as_ref().map_or(std::ptr::null(), SharedPointer::as_ptr);
+        // Note how we're casting the raw pointer changing from P to PO
+        // We cannot perform the equality it in a type safe way because the Root type depends
+        // on P/PO, and we can't pass different types to SharedPtr::same_ptr or std::ptr::eq.
+        let b = other
+            .root
+            .as_ref()
+            .map_or(std::ptr::null(), SharedPointer::as_ptr)
+            .cast::<Node<K, V, P>>();
+        std::ptr::eq(a, b)
+    }
+}
+
 impl<K, V: PartialEq, P, PO> PartialEq<RedBlackTreeMap<K, V, PO>> for RedBlackTreeMap<K, V, P>
 where
     K: Ord,

--- a/src/set/hash_trie_set/mod.rs
+++ b/src/set/hash_trie_set/mod.rs
@@ -212,7 +212,7 @@ where
 
     #[must_use]
     pub fn is_subset<I: BuildHasher + Clone>(&self, other: &HashTrieSet<T, P, I>) -> bool {
-        if self.map.same_root(&other.map) {
+        if self.ptr_eq(other) {
             return true;
         }
 
@@ -260,6 +260,24 @@ where
 {
     fn default() -> HashTrieSet<T, P, H> {
         HashTrieSet::new_with_hasher_with_ptr_kind(H::default())
+    }
+}
+
+impl<T, P, H: BuildHasher> HashTrieSet<T, P, H>
+where
+    T: Eq + Hash,
+    H: Clone,
+    P: SharedPointerKind,
+{
+    /// Test whether the two sets refer to the same content in memory.
+    ///
+    /// This would return true if you’re comparing a set to itself,
+    /// or if you’re comparing a set to a fresh clone of itself.
+    pub fn ptr_eq<PO: SharedPointerKind, I: BuildHasher + Clone>(
+        &self,
+        other: &HashTrieSet<T, PO, I>,
+    ) -> bool {
+        self.map.ptr_eq(&other.map)
     }
 }
 

--- a/src/set/hash_trie_set/mod.rs
+++ b/src/set/hash_trie_set/mod.rs
@@ -212,7 +212,11 @@ where
 
     #[must_use]
     pub fn is_subset<I: BuildHasher + Clone>(&self, other: &HashTrieSet<T, P, I>) -> bool {
-        self.iter().all(|v| other.contains(v))
+        if self.map.same_root(&other.map) {
+            return true;
+        }
+
+        self.size() <= other.size() && self.iter().all(|v| other.contains(v))
     }
 
     #[must_use]

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -217,6 +217,12 @@ where
     where
         PO: SharedPointerKind,
     {
+        if self.map.same_root(&other.map) {
+            return true;
+        }
+        if self.size() > other.size() {
+            return false;
+        }
         let mut other_it = other.iter();
 
         for v in self.iter() {

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -217,7 +217,7 @@ where
     where
         PO: SharedPointerKind,
     {
-        if self.map.same_root(&other.map) {
+        if self.ptr_eq(other) {
             return true;
         }
         if self.size() > other.size() {
@@ -292,6 +292,20 @@ where
 {
     fn default() -> RedBlackTreeSet<T, P> {
         RedBlackTreeSet::new_with_ptr_kind()
+    }
+}
+
+impl<T, P> RedBlackTreeSet<T, P>
+where
+    T: Ord,
+    P: SharedPointerKind,
+{
+    /// Test whether the two sets refer to the same content in memory.
+    ///
+    /// This would return true if you’re comparing a set to itself,
+    /// or if you’re comparing a set to a fresh clone of itself.
+    pub fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeSet<T, PO>) -> bool {
+        self.map.ptr_eq(&other.map)
     }
 }
 


### PR DESCRIPTION
Speedup rb-tree/hash-trie set operations based on their sizes and equality when data structures share the same root. I'm not including benchmarks because they're only fast paths, and not an overall improvement.