### PR TITLE
Draft: Map `replace`, which is like `insert`, but returns previous value (or entry?)

### DIFF
--- a/src/map/hash_trie_map/test.rs
+++ b/src/map/hash_trie_map/test.rs
@@ -135,19 +135,19 @@ mod bucket {
         // list must be preserved for the same reason.
 
         let mut bucket = bucket_single_a.clone();
-        assert!(!bucket.insert(entry_a9));
+        assert!(bucket.insert(entry_a9).is_some());
         assert_eq!(bucket, bucket_single_a9);
 
         let mut bucket = bucket_single_a;
-        assert!(bucket.insert(entry_b));
+        assert!(bucket.insert(entry_b).is_none());
         assert_eq!(bucket, bucket_collision_b_a);
 
         let mut bucket = bucket_collision_a_b_c.clone();
-        assert!(!bucket.insert(entry_b9));
+        assert!(bucket.insert(entry_b9).is_some());
         assert_eq!(bucket, bucket_collision_b9_a_c);
 
         let mut bucket = bucket_collision_a_b_c;
-        assert!(bucket.insert(entry_d));
+        assert!(bucket.insert(entry_d).is_none());
         assert_eq!(bucket, bucket_collision_d_a_b_c);
     }
 


### PR DESCRIPTION
This PR is a rough first draft to gather feedback, and just to have "something on the wall to point at". It runs and illustrates the idea, but does not have tests, and currently only implements for `HashTrieMap`.

## Motivation

In `std`, [`HashMap<K, V>::insert`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.insert) returns `Option<V>`, which contains the previous value if any. [`BTreeMap::insert` too](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.insert). It can avoid having to do an additional `get` before the `insert`.

I have a use-case where a similar method on `rpds` map types would help.

## Observations

I found these complications, and options for tackling them:

1. Being a persistent data structure, `insert` currently returns the new version of the map type. So it would have to return a tuple instead, which results in an annoying interface at the call site whenever you don't intend to use the old value (which I imagine is quite often);
   ```rust
   let (map, _old_value) = map.insert(k, v);
   ```

   Options:
   - Accept the crappier API, which also requires major semver bump, because it changes the interface of `insert`.
   - Leave `insert`/`insert_mut` as-is, and name the new methods `replace`/`replace_mut` instead. (I think this is better. It's what the PR currently does, with `insert`/`insert_mut` delegating to `replace`/`replace_mut` but discarding their other return value.)

2. Unless `V` is `Copy`, there's no way to get literally `Option<V>`, as other versions of the map may be holding references to the relevant refcounted `Entry` structs. So it would have to return `Option<SharedPointer<V, _>>` or similar, which is fine too; it's the equivalent for a persistent data structure.

   However, `V` is held inside an `Entry<K, V>`.

   Options:

   - From an implementation perspective, the simplest thing would be to just return a refcounted pointer to the whole `Entry`, since it and its fields are `pub`; `-> Option<SharedPointer<Entry<K, V>, P>>`. This adds cruft to the call site though, since the caller obviously already has the key;
     ```rust
     let (map, old_entry) = map.replace(k, v);
     let old_value = old_entry.value;
     ```
     On the other hand, it's possible that the user's type `K` has distinct values that still deliberately `Hash`/`Ord` as equal for some reason, in which case being able to fetch the key too could be useful. (Though that should probably be the realm of another future  method addition, akin to [`std::HashMap::entry`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry).)

     (This what the PR does currently.)

   - Invent a new struct like `SharedValue<V>(SharedPointer<Entry<K, V>, P>)`, which implements `Deref<Target = V>`. Then return `Option<SharedValue<V>>`.

     That's cleaner for the user, but feels weird to implement since it's so single-use. (I think this is better though, and would lean toward this being the API if this is added.)

Opinions?