### PR TITLE
Make ptr_eq public

### DIFF
--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -855,7 +855,7 @@ where
     ///
     /// This would return true if you’re comparing a map to itself,
     /// or if you’re comparing a map to a fresh clone of itself.
-    pub(crate) fn ptr_eq<PO: SharedPointerKind, HO: BuildHasher>(
+    pub fn ptr_eq<PO: SharedPointerKind, HO: BuildHasher>(
         &self,
         other: &HashTrieMap<K, V, PO, HO>,
     ) -> bool {

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -904,7 +904,7 @@ where
     ///
     /// This would return true if you’re comparing a map to itself,
     /// or if you’re comparing a map to a fresh clone of itself.
-    pub(crate) fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeMap<K, V, PO>) -> bool {
+    pub fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeMap<K, V, PO>) -> bool {
         let a = self.root.as_ref().map_or(core::ptr::null(), SharedPointer::as_ptr);
         // Note how we're casting the raw pointer changing from P to PO
         // We cannot perform the equality in a type safe way because the root type depends

--- a/src/set/hash_trie_set/mod.rs
+++ b/src/set/hash_trie_set/mod.rs
@@ -214,7 +214,7 @@ where
     ///
     /// This would return true if you’re comparing a set to itself,
     /// or if you’re comparing a set to a fresh clone of itself.
-    fn ptr_eq<PO: SharedPointerKind, HO: BuildHasher + Clone>(
+    pub fn ptr_eq<PO: SharedPointerKind, HO: BuildHasher + Clone>(
         &self,
         other: &HashTrieSet<T, PO, HO>,
     ) -> bool {

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -216,7 +216,7 @@ where
     ///
     /// This would return true if you’re comparing a set to itself,
     /// or if you’re comparing a set to a fresh clone of itself.
-    fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeSet<T, PO>) -> bool {
+    pub fn ptr_eq<PO: SharedPointerKind>(&self, other: &RedBlackTreeSet<T, PO>) -> bool {
         self.map.ptr_eq(&other.map)
     }
 


### PR DESCRIPTION
I was changing a codebase to use rpds 1.0 but noticed `ptr_eq` (from #74) [isn't pub anymore](https://github.com/orium/rpds/commit/5d934eef611c35705ed6a7a4b4ed83508faa621f).

This should be a valid public api in persistent data-structures. It's already in [`im`](https://docs.rs/im/latest/im/?search=ptr_eq) and in the [stdlib](https://doc.rust-lang.org/std/index.html?search=ptr_eq).
