### PR TITLE
Fix the tests of SparseArrayUsize so that it works on 32 bit computers.

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## 1.0.1
+
+* Fix the tests of `SparseArrayUsize` on 32-bit computers.  This issue did not affect production code which did work 
+  correctly on 32-bit platforms.
+
 ## 1.0.0
 
 * First stable version.  It’s time to commit to a stable release :).

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -362,7 +362,7 @@ where
 
         fmt.write_str("[")?;
 
-        for v in self.iter() {
+        for v in self {
             if !first {
                 fmt.write_str(", ")?;
             }

--- a/src/list/test.rs
+++ b/src/list/test.rs
@@ -118,8 +118,8 @@ fn test_first_mut() {
 
     assert_eq!(a.first(), Some(&0));
     assert_eq!(b.first(), Some(&-1));
-    assert!(a.iter().eq(vec![0, 1, 2, 3].iter()));
-    assert!(b.iter().eq(vec![-1, 1, 2, 3].iter()));
+    assert!(a.iter().eq([0, 1, 2, 3].iter()));
+    assert!(b.iter().eq([-1, 1, 2, 3].iter()));
 }
 
 #[test]

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -217,9 +217,9 @@ mod node_utils {
     use core::hash::Hasher;
     use core::mem::size_of_val;
 
-    // Returns the index of the array for the given hash on depth `depth`.
-    //
-    // When the hash is exhausted, meaning that we are at the maximum depth, this returns `None`.
+    /// Returns the index of the array for the given hash on depth `depth`.
+    ///
+    /// When the hash is exhausted, meaning that we are at the maximum depth, this returns `None`.
     #[inline]
     pub fn index_from_hash(hash: HashValue, depth: usize, degree: u8) -> Option<usize> {
         debug_assert!(degree.is_power_of_two());

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -17,7 +17,6 @@ use core::hash::BuildHasher;
 use core::hash::Hash;
 use core::iter;
 use core::iter::FromIterator;
-use core::mem::size_of;
 use core::ops::Index;
 use core::slice;
 use sparse_array_usize::SparseArrayUsize;
@@ -31,7 +30,7 @@ pub type IterKeys<'a, K, V, P> = iter::Map<Iter<'a, K, V, P>, fn((&'a K, &V)) ->
 pub type IterValues<'a, K, V, P> = iter::Map<Iter<'a, K, V, P>, fn((&K, &'a V)) -> &'a V>;
 
 #[allow(clippy::cast_possible_truncation)]
-const DEFAULT_DEGREE: u8 = 8 * size_of::<usize>() as u8;
+const DEFAULT_DEGREE: u8 = usize::BITS as u8;
 
 /// Creates a [`HashTrieMap`](crate::HashTrieMap) containing the given arguments:
 ///

--- a/src/map/hash_trie_map/sparse_array_usize/test.rs
+++ b/src/map/hash_trie_map/sparse_array_usize/test.rs
@@ -4,10 +4,9 @@
  */
 
 use super::*;
-use core::mem::size_of;
 use pretty_assertions::assert_eq;
 
-const USIZE_BITS: usize = 8 * size_of::<usize>();
+const USIZE_BITS: usize = usize::BITS as usize;
 
 #[test]
 fn test_new() {

--- a/src/map/hash_trie_map/sparse_array_usize/test.rs
+++ b/src/map/hash_trie_map/sparse_array_usize/test.rs
@@ -4,7 +4,10 @@
  */
 
 use super::*;
+use core::mem::size_of;
 use pretty_assertions::assert_eq;
+
+const USIZE_BITS: usize = 8 * size_of::<usize>();
 
 #[test]
 fn test_new() {
@@ -21,7 +24,7 @@ fn test_set() {
 
     assert_eq!(array.size(), 0);
     assert_eq!(array.get(0), None);
-    assert_eq!(array.get(63), None);
+    assert_eq!(array.get(USIZE_BITS - 1), None);
 
     array.set(3, 'a');
     assert_eq!(array.size(), 1);
@@ -30,17 +33,17 @@ fn test_set() {
     assert_eq!(array.get(3), Some(&'a'));
     assert_eq!(array.get(4), None);
 
-    array.set(60, 'b');
+    array.set(USIZE_BITS - 4, 'b');
     assert_eq!(array.size(), 2);
 
     assert_eq!(array.get(3), Some(&'a'));
-    assert_eq!(array.get(60), Some(&'b'));
+    assert_eq!(array.get(USIZE_BITS - 4), Some(&'b'));
 
     array.set(3, 'c');
     assert_eq!(array.size(), 2);
 
     assert_eq!(array.get(3), Some(&'c'));
-    assert_eq!(array.get(60), Some(&'b'));
+    assert_eq!(array.get(USIZE_BITS - 4), Some(&'b'));
 }
 
 #[test]
@@ -48,27 +51,27 @@ fn test_remove() {
     let mut array = SparseArrayUsize::new();
 
     array.set(3, 'a');
-    array.set(60, 'b');
+    array.set(USIZE_BITS - 4, 'b');
 
     assert_eq!(array.get(3), Some(&'a'));
-    assert_eq!(array.get(60), Some(&'b'));
+    assert_eq!(array.get(USIZE_BITS - 4), Some(&'b'));
 
-    array.remove(32);
+    array.remove(8);
 
     assert_eq!(array.get(3), Some(&'a'));
-    assert_eq!(array.get(60), Some(&'b'));
+    assert_eq!(array.get(USIZE_BITS - 4), Some(&'b'));
     assert_eq!(array.size(), 2);
 
     array.remove(3);
 
     assert_eq!(array.get(3), None);
-    assert_eq!(array.get(60), Some(&'b'));
+    assert_eq!(array.get(USIZE_BITS - 4), Some(&'b'));
     assert_eq!(array.size(), 1);
 
-    array.remove(60);
+    array.remove(USIZE_BITS - 4);
 
     assert_eq!(array.get(3), None);
-    assert_eq!(array.get(60), None);
+    assert_eq!(array.get(USIZE_BITS - 4), None);
     assert_eq!(array.size(), 0);
 }
 
@@ -78,10 +81,10 @@ fn test_first() {
 
     assert_eq!(array.first(), None);
 
-    array.set(31, 'a');
+    array.set(8, 'a');
     assert_eq!(array.first(), Some(&'a'));
 
-    array.set(60, 'b');
+    array.set(USIZE_BITS - 4, 'b');
     assert_eq!(array.first(), Some(&'a'));
 
     array.set(2, 'c');
@@ -95,8 +98,8 @@ fn test_first() {
 fn test_pop() {
     let mut array = SparseArrayUsize::new();
 
-    array.set(60, 'b');
-    array.set(31, 'a');
+    array.set(USIZE_BITS - 4, 'b');
+    array.set(8, 'a');
 
     assert_eq!(array.pop(), Some('b'));
     assert_eq!(array.pop(), Some('a'));

--- a/src/map/hash_trie_map/test.rs
+++ b/src/map/hash_trie_map/test.rs
@@ -742,7 +742,7 @@ mod iter {
     fn test_iter_keys() {
         let map = ht_map![0 => 10, 1 => 11, 2 => 12];
 
-        let mut touched = vec![false; 3];
+        let mut touched = [false; 3];
 
         for k in map.keys() {
             assert!(!touched[*k as usize]);
@@ -756,7 +756,7 @@ mod iter {
     fn test_iter_values() {
         let map = ht_map![10 => 0, 11 => 1, 12 => 2];
 
-        let mut touched = vec![false; 3];
+        let mut touched = [false; 3];
 
         for v in map.values() {
             assert!(!touched[*v as usize]);
@@ -1191,8 +1191,7 @@ fn test_display() {
     assert_eq!(format!("{}", empty_map), "{}");
     assert_eq!(format!("{}", singleton_map), "{hi: hello}");
     assert!(
-        format!("{}", map) == "{5: hello, 12: there}"
-            || format!("{}", map) == "{12: there, 5: hello}"
+        format!("{map}") == "{5: hello, 12: there}" || format!("{map}") == "{12: there, 5: hello}"
     );
 }
 

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -1092,7 +1092,7 @@ where
 
         fmt.write_str("{")?;
 
-        for (k, v) in self.iter() {
+        for (k, v) in self {
             if !first {
                 fmt.write_str(", ")?;
             }

--- a/src/map/red_black_tree_map/test.rs
+++ b/src/map/red_black_tree_map/test.rs
@@ -1059,7 +1059,7 @@ mod internal {
     fn remove_test(values_insert: &[u32], values_remove: &[u32]) {
         let mut map = RedBlackTreeMap::new();
 
-        for &v in values_insert.iter() {
+        for &v in values_insert {
             map.insert_mut(v, 2 * v);
         }
 

--- a/src/queue/mod.rs
+++ b/src/queue/mod.rs
@@ -275,7 +275,7 @@ where
 
         fmt.write_str("Queue(")?;
 
-        for v in self.iter() {
+        for v in self {
             if !first {
                 fmt.write_str(", ")?;
             }

--- a/src/set/hash_trie_set/test.rs
+++ b/src/set/hash_trie_set/test.rs
@@ -294,7 +294,7 @@ fn test_display() {
 
     assert_eq!(format!("{}", empty_set), "{}");
     assert_eq!(format!("{}", singleton_set), "{hi}");
-    assert!(format!("{}", set) == "{5, 12}" || format!("{}", set) == "{12, 5}");
+    assert!(format!("{set}") == "{5, 12}" || format!("{set}") == "{12, 5}");
 }
 
 #[test]

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -233,7 +233,7 @@ where
         }
         let mut other_it = other.iter();
 
-        for v in self.iter() {
+        for v in self {
             loop {
                 match other_it.next() {
                     Some(u) => match u.cmp(v) {
@@ -366,7 +366,7 @@ where
 
         fmt.write_str("{")?;
 
-        for v in self.iter() {
+        for v in self {
             if !first {
                 fmt.write_str(", ")?;
             }

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -242,7 +242,7 @@ where
 
         fmt.write_str("Stack(")?;
 
-        for v in self.iter() {
+        for v in self {
             if !first {
                 fmt.write_str(", ")?;
             }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -527,7 +527,7 @@ where
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
-        self.get(index).unwrap_or_else(|| panic!("index out of bounds {}", index))
+        self.get(index).unwrap_or_else(|| panic!("index out of bounds {index}"))
     }
 }
 
@@ -536,7 +536,7 @@ where
     P: SharedPointerKind,
 {
     fn index_mut(&mut self, index: usize) -> &mut T {
-        self.get_mut(index).unwrap_or_else(|| panic!("index out of bounds {}", index))
+        self.get_mut(index).unwrap_or_else(|| panic!("index out of bounds {index}"))
     }
 }
 
@@ -613,7 +613,7 @@ where
 
         fmt.write_str("[")?;
 
-        for v in self.iter() {
+        for v in self {
             if !first {
                 fmt.write_str(", ")?;
             }


### PR DESCRIPTION
This issue did not affect production code which did work correctly on 32-bit
platforms.

Closes #81.