### PR TITLE
Use `triomphe::Arc` by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,9 @@ include = [
 codecov = { repository = "orium/rpds", branch = "master", service = "github" }
 
 [dependencies]
-archery = "1.0.0"
+# FIXME(sproul): update after release
+# archery = "1.0.0"
+archery = { git = "https://github.com/orium/archery.git", rev = "bf910da0c5069e6f72fd34c2c16da51a2c0af91b", features = ["triomphe"] }
 serde = { version = "1.0.149", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ crate to do this in a convenient way.
 The pointer type can be parameterized like this:
 
 ```rust
-let vec: Vector<u32, archery::ArcK> = Vector::new_with_ptr_kind();
+let vec: Vector<u32, archery::ArcTK> = Vector::new_with_ptr_kind();
 //                              ↖
 //                                This will use `Arc` pointers.
 //                                Change it to `archery::RcK` to use a `Rc` pointer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@
 //! ```rust
 //! # use rpds::Vector;
 //! #
-//! let vec: Vector<u32, archery::ArcK> = Vector::new_with_ptr_kind();
+//! let vec: Vector<u32, archery::ArcTK> = Vector::new_with_ptr_kind();
 //! //                              ↖
 //! //                                This will use `Arc` pointers.
 //! //                                Change it to `archery::RcK` to use a `Rc` pointer.

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -79,7 +79,7 @@ macro_rules! list {
 #[macro_export]
 macro_rules! list_sync {
     ($($e:expr),*) => {
-        $crate::list_reverse!(::archery::ArcK ; $($e),* ; )
+        $crate::list_reverse!(::archery::ArcTK ; $($e),* ; )
     };
 }
 
@@ -137,7 +137,7 @@ where
     }
 }
 
-pub type ListSync<T> = List<T, ArcK>;
+pub type ListSync<T> = List<T, ArcTK>;
 
 impl<T> ListSync<T> {
     #[must_use]

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -10,7 +10,7 @@ use crate::list;
 use crate::utils::DefaultBuildHasher;
 use crate::List;
 use alloc::vec::Vec;
-use archery::{ArcK, RcK, SharedPointer, SharedPointerKind};
+use archery::{ArcTK, RcK, SharedPointer, SharedPointerKind};
 use core::borrow::Borrow;
 use core::fmt::Display;
 use core::hash::BuildHasher;
@@ -126,7 +126,7 @@ where
     hasher_builder: H,
 }
 
-pub type HashTrieMapSync<K, V, H = DefaultBuildHasher> = HashTrieMap<K, V, ArcK, H>;
+pub type HashTrieMapSync<K, V, H = DefaultBuildHasher> = HashTrieMap<K, V, ArcTK, H>;
 
 /// This map works like a trie that breaks the hash of the key in segments, and the segments are
 /// used as the index in the trie branches.

--- a/src/map/red_black_tree_map/mod.rs
+++ b/src/map/red_black_tree_map/mod.rs
@@ -4,7 +4,7 @@
  */
 
 use super::entry::Entry;
-use archery::{ArcK, RcK, SharedPointer, SharedPointerKind};
+use archery::{ArcTK, RcK, SharedPointer, SharedPointerKind};
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::Display;
@@ -113,7 +113,7 @@ where
     size: usize,
 }
 
-pub type RedBlackTreeMapSync<K, V> = RedBlackTreeMap<K, V, ArcK>;
+pub type RedBlackTreeMapSync<K, V> = RedBlackTreeMap<K, V, ArcTK>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Color {

--- a/src/queue/mod.rs
+++ b/src/queue/mod.rs
@@ -107,7 +107,7 @@ where
     out_list: List<T, P>,
 }
 
-pub type QueueSync<T> = Queue<T, ArcK>;
+pub type QueueSync<T> = Queue<T, ArcTK>;
 
 impl<T> QueueSync<T> {
     #[must_use]

--- a/src/set/hash_trie_set/mod.rs
+++ b/src/set/hash_trie_set/mod.rs
@@ -6,7 +6,7 @@
 use crate::map::hash_trie_map;
 use crate::utils::DefaultBuildHasher;
 use crate::HashTrieMap;
-use archery::{ArcK, RcK, SharedPointerKind};
+use archery::{ArcTK, RcK, SharedPointerKind};
 use core::borrow::Borrow;
 use core::fmt::Display;
 use core::hash::BuildHasher;
@@ -104,7 +104,7 @@ where
     map: HashTrieMap<T, (), P, H>,
 }
 
-pub type HashTrieSetSync<T, H = DefaultBuildHasher> = HashTrieSet<T, ArcK, H>;
+pub type HashTrieSetSync<T, H = DefaultBuildHasher> = HashTrieSet<T, ArcTK, H>;
 
 impl<T> HashTrieSet<T, RcK, DefaultBuildHasher>
 where

--- a/src/set/red_black_tree_set/mod.rs
+++ b/src/set/red_black_tree_set/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::map::red_black_tree_map;
 use crate::RedBlackTreeMap;
-use archery::{ArcK, RcK, SharedPointerKind};
+use archery::{ArcTK, RcK, SharedPointerKind};
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::Display;
@@ -104,7 +104,7 @@ where
     map: RedBlackTreeMap<T, (), P>,
 }
 
-pub type RedBlackTreeSetSync<T> = RedBlackTreeSet<T, ArcK>;
+pub type RedBlackTreeSetSync<T> = RedBlackTreeSet<T, ArcTK>;
 
 impl<T> RedBlackTreeSetSync<T>
 where

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -100,7 +100,7 @@ where
     list: List<T, P>,
 }
 
-pub type StackSync<T> = Stack<T, ArcK>;
+pub type StackSync<T> = Stack<T, ArcTK>;
 
 impl<T> StackSync<T> {
     #[must_use]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -106,7 +106,7 @@ where
     length: usize,
 }
 
-pub type VectorSync<T> = Vector<T, ArcK>;
+pub type VectorSync<T> = Vector<T, ArcTK>;
 
 #[derive(Debug)]
 enum Node<T, P = RcK>


### PR DESCRIPTION
Change the default `Arc` backend to `triomphe`, which results in speedups of up to 40% (per https://github.com/orium/rpds/pull/85).

The default backend is changed to `ArcTK`, while retaining the ability for the user to swap out to `ArcK` if they prefer.

This PR _does not_ currently include the ability to completely compile-out `triomphe`. If that were desired, we would have to expose a feature called `triomphe` which controls the backend, and causes `std::sync::Arc` to be used when the feature is disabled.