### PR TITLE
Use smallvec for hashtriemap iteration stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ codecov = { repository = "orium/rpds", branch = "main", service = "github" }
 archery = { version = "1.2.2", features = ["triomphe"] }
 rayon = { version = "1.11.0", optional = true }
 serde = { version = "1.0.228", optional = true, default-features = false }
+smallvec = { version = "1.15.1", features = ["const_generics"] }
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/benches/rpds_hash_trie_map.rs
+++ b/benches/rpds_hash_trie_map.rs
@@ -100,22 +100,28 @@ fn rpds_hash_trie_map_get(c: &mut Criterion) {
         });
     });
 }
-
-fn rpds_hash_trie_map_iterate(c: &mut Criterion) {
-    let limit = 100_000;
+fn rpds_hash_trie_map_iterate_impl(c: &mut Criterion, limit: usize, bench_name: &str) {
     let mut map = HashTrieMap::new();
 
     for i in 0..limit {
         map.insert_mut(i, -(i as isize));
     }
 
-    c.bench_function("rpds hash trie map iterate", move |b| {
+    c.bench_function(bench_name, move |b| {
         b.iter(|| {
             for kv in map.iter() {
                 black_box(kv);
             }
         });
     });
+}
+
+fn rdps_hash_trie_map_iterate_big(c: &mut Criterion) {
+    rpds_hash_trie_map_iterate_impl(c, 100_000, "rpds hash trie map iterate big");
+}
+
+fn rpds_hash_trie_map_iterate_small(c: &mut Criterion) {
+    rpds_hash_trie_map_iterate_impl(c, 10, "rpds hash trie map iterate small");
 }
 
 criterion_group!(
@@ -125,6 +131,7 @@ criterion_group!(
     rpds_hash_trie_map_remove,
     rpds_hash_trie_map_remove_mut,
     rpds_hash_trie_map_get,
-    rpds_hash_trie_map_iterate
+    rdps_hash_trie_map_iterate_big,
+    rpds_hash_trie_map_iterate_small
 );
 criterion_main!(benches);

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -1034,7 +1034,7 @@ where
     }
 }
 
-const ITER_STACK_N_INLINE: usize = iter_utils::trie_max_height(DEFAULT_DEGREE) + 1;
+const ITER_STACK_N_INLINE: usize = 4;
 
 type IterPtrStack<'a, K, V, P> = SmallVec<[IterStackElement<'a, K, V, P>; ITER_STACK_N_INLINE]>;
 
@@ -1089,17 +1089,6 @@ where
             IterStackElement::LeafCollision(i) => i.next().map(|i| Ok(&i.entry)),
             IterStackElement::LeafSingle(i) => i.next().map(Ok),
         }
-    }
-}
-
-mod iter_utils {
-    use super::HashValue;
-
-    pub const fn trie_max_height(degree: u8) -> usize {
-        let bits_per_level = (degree - 1).count_ones() as usize;
-        let hash_bits = HashValue::BITS as usize;
-
-        (hash_bits / bits_per_level) + (hash_bits % bits_per_level > 0) as usize
     }
 }
 

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -16,6 +16,7 @@ use core::iter;
 use core::iter::FromIterator;
 use core::ops::Index;
 use core::slice;
+use smallvec::SmallVec;
 use sparse_array_usize::SparseArrayUsize;
 
 type HashValue = u64;
@@ -1033,12 +1034,16 @@ where
     }
 }
 
+const ITER_STACK_N_INLINE: usize = iter_utils::trie_max_height(DEFAULT_DEGREE) + 1;
+
+type IterPtrStack<'a, K, V, P> = SmallVec<[IterStackElement<'a, K, V, P>; ITER_STACK_N_INLINE]>;
+
 #[derive(Debug)]
 pub struct IterPtr<'a, K, V, P>
 where
     P: SharedPointerKind,
 {
-    stack: Vec<IterStackElement<'a, K, V, P>>,
+    stack: IterPtrStack<'a, K, V, P>,
     size: usize,
 }
 
@@ -1090,11 +1095,11 @@ where
 mod iter_utils {
     use super::HashValue;
 
-    pub fn trie_max_height(degree: u8) -> usize {
+    pub const fn trie_max_height(degree: u8) -> usize {
         let bits_per_level = (degree - 1).count_ones() as usize;
         let hash_bits = HashValue::BITS as usize;
 
-        (hash_bits / bits_per_level) + usize::from(hash_bits % bits_per_level > 0)
+        (hash_bits / bits_per_level) + (hash_bits % bits_per_level > 0) as usize
     }
 }
 
@@ -1104,8 +1109,7 @@ where
     P: SharedPointerKind,
 {
     fn new<H: BuildHasher + Clone>(map: &HashTrieMap<K, V, P, H>) -> IterPtr<'_, K, V, P> {
-        let mut stack: Vec<IterStackElement<'_, K, V, P>> =
-            Vec::with_capacity(iter_utils::trie_max_height(map.degree) + 1);
+        let mut stack = IterPtrStack::new();
 
         if map.size() > 0 {
             stack.push(IterStackElement::new(map.root.borrow()));

--- a/src/map/hash_trie_map/mod.rs
+++ b/src/map/hash_trie_map/mod.rs
@@ -1053,7 +1053,7 @@ where
     P: SharedPointerKind,
 {
     Branch(slice::Iter<'a, SharedPointer<Node<K, V, P>, P>>),
-    LeafCollision(list::Iter<'a, EntryWithHash<K, V, P>, P>),
+    LeafCollision(list::IterPtr<'a, EntryWithHash<K, V, P>, P>),
     LeafSingle(iter::Once<&'a SharedPointer<Entry<K, V>, P>>),
 }
 
@@ -1067,7 +1067,7 @@ where
         match node {
             Node::Branch(children) => IterStackElement::Branch(children.iter()),
             Node::Leaf(Bucket::Collision(entries)) => {
-                IterStackElement::LeafCollision(entries.iter())
+                IterStackElement::LeafCollision(entries.iter_ptr())
             }
             Node::Leaf(Bucket::Single(entry)) => {
                 IterStackElement::LeafSingle(iter::once(&entry.entry))


### PR DESCRIPTION
We've noticed that hashtriemap iteration is somewhat expensive in production profiles. One contributor seems to be that we allocate a Vec with every iterator, and we have a large number of usually-small maps that we iterate. This PR avoids that allocation by using smallvec.

Opening for feedback. If you'd rather not add a smallvec dependency I will look for another approach.

When I run the iter microbenchmarks (the existing one and the new one I added) on my laptop, this looks like about a 5% regression on iterating a map with 100,000 keys, and a 50% improvement on iterating over a map with 10 keys.

(h/t @nelhage for [a first pass at this](https://github.com/orium/rpds/compare/main...nelhage:rpds:hamt-iter-smallvec?expand=1) which I adopted)